### PR TITLE
fix(invoices): enforce Mercury text-field limits in Zod (lineItem.nam…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `lineItemSchema.name` now enforces `.min(1).max(200)` at the Zod level. Mercury silently accepts longer names on `POST /ar/invoices` (create) but rejects them on the edit endpoint with `"Item name: Must be 200 characters or fewer"`, leaving the invoice in an unmodifiable state. The MCP now refuses upfront with a clean validation error.
+- `invoiceNumber` now enforces `.max(255)`. Mercury accepts up to ~280 characters and rejects 300+, so 255 is a safe ceiling that also matches typical varchar(255) database conventions.
+
+### Tested but not enforced (no schema-level limit needed)
+- `payerMemo`, `internalNote`, `customer.name` all accept ≥5000 characters in production. No artificial limit added.
+
 ## [0.2.0] - 2026-04-17
 
 ### Added

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -4,7 +4,13 @@ import { z } from "zod";
 import { MercuryClient } from "../client.js";
 
 const lineItemSchema = z.object({
-  name: z.string().describe("Line item name (required by Mercury, shown on the invoice)"),
+  name: z
+    .string()
+    .min(1)
+    .max(200)
+    .describe(
+      "Line item name (required, ≤200 characters — Mercury rejects longer values on the edit endpoint with 'Item name: Must be 200 characters or fewer', leaving the invoice unmodifiable). Put long descriptions in the optional `description` field or in the attached invoice PDF.",
+    ),
   description: z.string().optional().describe("Optional longer description"),
   quantity: z.number().positive().describe("Quantity"),
   unitPrice: z.number().nonnegative().describe("Price per unit in USD"),
@@ -87,7 +93,7 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
         .enum(["DontSend", "SendNow"])
         .optional()
         .describe("Whether to email the invoice immediately. Default: SendNow"),
-      invoiceNumber: z.string().optional().describe("Customer-facing invoice number"),
+      invoiceNumber: z.string().max(255).optional().describe("Customer-facing invoice number (≤255 chars; Mercury rejects 300+ characters on the edit endpoint)"),
       poNumber: z.string().optional().describe("Purchase order number"),
       payerMemo: z.string().optional().describe("Memo shown to payer"),
       internalNote: z.string().optional().describe("Note visible only to your org"),


### PR DESCRIPTION
…e 200, invoiceNumber 255)

Mercury silently accepts long values on POST /ar/invoices (create) but rejects them on POST /ar/invoices/{id} (edit). Result: callers can create an invoice that they then cannot amend (e.g. to fix a typo, change due date, etc.).

Production-tested limits:
- lineItem.name: 200 chars hard limit (Mercury error: 'Item name: Must be 200 characters or fewer'). Discovered with INV-36 at 238 chars.
- invoiceNumber: 280 chars OK, 300+ REJECTED. Setting .max(255) for safety.
- payerMemo / internalNote / customer.name all accept ≥5000 chars in production — no schema-level limit added.

The MCP now refuses oversized values upfront with a clean Zod validation error instead of letting users discover the issue at edit time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for invoice line items and invoice numbers to enforce maximum length constraints, preventing submission of data that would be rejected during editing and ensuring invoices remain fully modifiable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->