### PR TITLE
feat: Snyk badge in README + Sigstore signing of release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,44 @@ on:
     types: [published]
   workflow_dispatch:
 
+# Default workflow permissions: read-only. The publish job below escalates
+# only what it needs, only for release events.
 permissions:
-  contents: write   # needed to upload signed artifacts to the GitHub Release
-  id-token: write   # needed for npm provenance + Sigstore keyless signing
+  contents: read
 
 jobs:
-  publish:
-    name: Publish to npm + sign release artifacts
+  build:
+    name: Build & Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+
+      - name: Setup Node 20
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.0.0
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test -- --coverage
+
+  publish:
+    name: Sign release artifacts + publish to npm
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # upload signed artifacts to the GitHub Release
+      id-token: write   # npm provenance + Sigstore keyless signing
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
@@ -27,26 +57,22 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
+      - name: Build (production, sourcemaps stripped)
         run: npm run build
+        env:
+          NODE_ENV: production
 
-      - name: Test
-        run: npm test -- --coverage
-
-      # Sign + upload signed assets BEFORE the (non-idempotent) npm publish, so
-      # a transient failure on signing or asset upload doesn't leave us stuck
-      # with a published version we cannot re-build the workflow for.
+      # Sign + upload signed assets BEFORE the (non-idempotent) npm publish,
+      # so a transient failure on signing or asset upload doesn't leave us
+      # stuck with a published version we cannot re-run the workflow for.
 
       - name: Install Sigstore CLI
-        if: github.event_name == 'release'
         run: npm install -g @sigstore/cli@1.0.0
 
       - name: Sign dist/index.js with Sigstore (keyless OIDC, bundle format)
-        if: github.event_name == 'release'
         run: sigstore sign --bundle dist/index.js.sigstore dist/index.js
 
       - name: Attach signed artifacts to the GitHub Release
-        if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -57,7 +83,6 @@ jobs:
             --clobber
 
       - name: Publish to npm
-        if: github.event_name == 'release'
         run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install Sigstore CLI
-        run: npm install -g @sigstore/cli@^1.0.0
+        run: npm install -g @sigstore/cli@1.0.0
 
-      - name: Sign dist/index.js with Sigstore (keyless, OIDC)
-        run: sigstore sign --output-signature dist/index.js.sigstore dist/index.js
+      - name: Sign dist/index.js with Sigstore (keyless OIDC, bundle format)
+        run: sigstore sign --bundle dist/index.js.sigstore dist/index.js
 
       - name: Attach signed artifacts to the GitHub Release
         if: github.event_name == 'release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,15 +33,16 @@ jobs:
       - name: Test
         run: npm test -- --coverage
 
-      - name: Publish to npm
-        run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Sign + upload signed assets BEFORE the (non-idempotent) npm publish, so
+      # a transient failure on signing or asset upload doesn't leave us stuck
+      # with a published version we cannot re-build the workflow for.
 
       - name: Install Sigstore CLI
+        if: github.event_name == 'release'
         run: npm install -g @sigstore/cli@1.0.0
 
       - name: Sign dist/index.js with Sigstore (keyless OIDC, bundle format)
+        if: github.event_name == 'release'
         run: sigstore sign --bundle dist/index.js.sigstore dist/index.js
 
       - name: Attach signed artifacts to the GitHub Release
@@ -54,3 +55,9 @@ jobs:
             dist/index.js.sigstore \
             --repo "${{ github.repository }}" \
             --clobber
+
+      - name: Publish to npm
+        if: github.event_name == 'release'
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,12 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  id-token: write
+  contents: write   # needed to upload signed artifacts to the GitHub Release
+  id-token: write   # needed for npm provenance + Sigstore keyless signing
 
 jobs:
   publish:
-    name: Publish to npm
+    name: Publish to npm + sign release artifacts
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,3 +37,20 @@ jobs:
         run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install Sigstore CLI
+        run: npm install -g @sigstore/cli@^1.0.0
+
+      - name: Sign dist/index.js with Sigstore (keyless, OIDC)
+        run: sigstore sign --output-signature dist/index.js.sigstore dist/index.js
+
+      - name: Attach signed artifacts to the GitHub Release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            dist/index.js \
+            dist/index.js.sigstore \
+            --repo "${{ github.repository }}" \
+            --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - README: Snyk Known Vulnerabilities badge.
 - `release.yml`: Sigstore (keyless OIDC) signing of `dist/index.js`. The signed artifact + `.sigstore` bundle are uploaded to the GitHub Release. This satisfies Scorecard's `Signed-Releases` check (npm provenance alone doesn't, because Scorecard inspects GitHub Release assets, not the npm tarball).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- README: Snyk Known Vulnerabilities badge.
+- `release.yml`: Sigstore (keyless OIDC) signing of `dist/index.js`. The signed artifact + `.sigstore` bundle are uploaded to the GitHub Release. This satisfies Scorecard's `Signed-Releases` check (npm provenance alone doesn't, because Scorecard inspects GitHub Release assets, not the npm tarball).
+
 ### Changed
 - `lineItemSchema.name` now enforces `.min(1).max(200)` at the Zod level. Mercury silently accepts longer names on `POST /ar/invoices` (create) but rejects them on the edit endpoint with `"Item name: Must be 200 characters or fewer"`, leaving the invoice in an unmodifiable state. The MCP now refuses upfront with a clean validation error.
 - `invoiceNumber` now enforces `.max(255)`. Mercury accepts up to ~280 characters and rejects 300+, so 255 is a safe ceiling that also matches typical varchar(255) database conventions.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![codecov](https://codecov.io/gh/klodr/mercury-invoicing-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/klodr/mercury-invoicing-mcp)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/klodr/mercury-invoicing-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/klodr/mercury-invoicing-mcp)
 [![Socket Security](https://socket.dev/api/badge/npm/package/mercury-invoicing-mcp)](https://socket.dev/npm/package/mercury-invoicing-mcp)
+[![Known Vulnerabilities](https://snyk.io/test/github/klodr/mercury-invoicing-mcp/badge.svg)](https://snyk.io/test/github/klodr/mercury-invoicing-mcp)
 
 [![npm version](https://img.shields.io/npm/v/mercury-invoicing-mcp.svg)](https://www.npmjs.com/package/mercury-invoicing-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/mercury-invoicing-mcp.svg)](https://www.npmjs.com/package/mercury-invoicing-mcp)


### PR DESCRIPTION
- README: add Snyk Known Vulnerabilities badge alongside Socket / Scorecard
- release.yml: sign dist/index.js with Sigstore (keyless, OIDC) and attach the signed artifact + .sigstore bundle to the GitHub Release. This satisfies Scorecard's Signed-Releases check (npm provenance alone is not enough — Scorecard inspects GitHub Release assets).

Adds 'contents: write' permission to the release workflow so it can upload assets via gh release upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Snyk "Known Vulnerabilities" badge to README and recorded the change in CHANGELOG.

* **Chores**
  * Release flow split into build and publish stages; publish now runs only for release events.
  * Build artifacts are cryptographically signed and the signed bundle is uploaded to GitHub Releases; npm publish continues with provenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->