### PR TITLE
fix(release): replace wrong @sigstore/cli@1.0.0 with actions/attest-b…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
         run: |
+          test -n "${BUNDLE_PATH:-}" || { echo "Missing attestation bundle-path output"; exit 1; }
+          test -f "$BUNDLE_PATH" || { echo "Bundle file not found: $BUNDLE_PATH"; exit 1; }
           cp "$BUNDLE_PATH" dist/index.js.sigstore
           gh release upload "${{ github.event.release.tag_name }}" \
             dist/index.js \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,9 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # upload signed artifacts to the GitHub Release
-      id-token: write   # npm provenance + Sigstore keyless signing
+      contents: write       # upload signed artifacts to the GitHub Release
+      id-token: write       # npm provenance + Sigstore keyless signing
+      attestations: write   # actions/attest-build-provenance writes to the attestation API
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
@@ -66,16 +67,18 @@ jobs:
       # so a transient failure on signing or asset upload doesn't leave us
       # stuck with a published version we cannot re-run the workflow for.
 
-      - name: Install Sigstore CLI
-        run: npm install -g @sigstore/cli@1.0.0
-
-      - name: Sign dist/index.js with Sigstore (keyless OIDC, bundle format)
-        run: sigstore sign --bundle dist/index.js.sigstore dist/index.js
+      - name: Generate Sigstore attestation for dist/index.js
+        id: attest
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: dist/index.js
 
       - name: Attach signed artifacts to the GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
         run: |
+          cp "$BUNDLE_PATH" dist/index.js.sigstore
           gh release upload "${{ github.event.release.tag_name }}" \
             dist/index.js \
             dist/index.js.sigstore \


### PR DESCRIPTION
…uild-provenance

The previous release workflow ran `npm install -g @sigstore/cli@1.0.0` followed by `sigstore sign --bundle ...`, but:

- @sigstore/cli has never published a 1.0.0 (latest is 0.9.1).
- @sigstore/cli does not expose a `sign` subcommand at all (it has `attest`, `verify`, `attach`).

Both lines were wrong from PR #13 and broke the v0.6.0 release run.

Switch to actions/attest-build-provenance@v4.1.0 (pinned by SHA, like the rest of the workflow):

- Official GitHub action, native Sigstore-backed attestation.
- Recognised by OpenSSF Scorecard's Signed-Releases check.
- Zero external CLI to install — fewer moving parts.

The action's `bundle-path` output is copied to `dist/index.js.sigstore` so the existing `gh release upload` line keeps the same asset name.

Adds the `attestations: write` permission required by the action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the release workflow to generate a provenance attestation using GitHub Actions native tooling instead of the prior signing step.
  * Expanded workflow permissions to allow writing attestation data and ensured the release process validates and attaches the generated attestation alongside the published artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->