### PR TITLE
chore(release): 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-04-18
+
+### Fixed
+- `release.yml`: replaced the incorrect `@sigstore/cli@1.0.0` install (no such version, no `sign` subcommand) with `actions/attest-build-provenance@v4.1.0`. The v0.6.0 release run failed at the install step, so 0.6.0 was never published to npm — 0.6.1 ships the same code as 0.6.0 plus a working signing pipeline.
+- `release.yml`: added a `BUNDLE_PATH` guard before `cp` so a missing attestation output produces a self-explanatory error instead of a generic `cp` failure.
+
 ## [0.6.0] - 2026-04-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.1] - 2026-04-18
 
 ### Fixed
+
 - `release.yml`: replaced the incorrect `@sigstore/cli@1.0.0` install (no such version, no `sign` subcommand) with `actions/attest-build-provenance@v4.1.0`. The v0.6.0 release run failed at the install step, so 0.6.0 was never published to npm — 0.6.1 ships the same code as 0.6.0 plus a working signing pipeline.
 - `release.yml`: added a `BUNDLE_PATH` guard before `cp` so a missing attestation output produces a self-explanatory error instead of a generic `cp` failure.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { registerAllTools } from "./tools/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.6.0";
+export const VERSION = "0.6.1";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 export interface ServerOptions {


### PR DESCRIPTION
## Summary

  Patch release that ships 0.6.0's code with a working signing pipeline.

  The v0.6.0 release run failed at the Sigstore CLI install step (#15 fixes the workflow). 0.6.0 was never published to npm. This bump:

  - Pulls in the workflow fix (PR #15: `actions/attest-build-provenance@v4.1.0` + `BUNDLE_PATH` guard)
  - No source code changes vs 0.6.0

  ## Test plan
  - [ ] CI green
  - [ ] After merge: tag v0.6.1 + create Release → first end-to-end run of the new signing pipeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow error handling to provide clearer error messages when build attestation validation fails, preventing confusing fallback errors.

* **Version**
  * Released version 0.6.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->