### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-04-18
+
 ### Added
 
-- `test/fuzz.test.ts`: property-based tests using `fast-check`. Covers `redactSensitive` (no leak through any sensitive key at any depth, structure preservation) and `MercuryError` (toString / toJSON never expose the response body). Recognised by OpenSSF Scorecard as a fuzz testing tool.
-- `release.yml`: now also emits `dist/index.js.intoto.jsonl` (SLSA in-toto attestation extracted from the Sigstore bundle's DSSE envelope) alongside `dist/index.js.sigstore`. Lifts Scorecard's `Signed-Releases` check from 8/10 to 10/10.
+- `test/fuzz.test.ts`: property-based tests using `fast-check`. Covers `redactSensitive` (no leak through any sensitive key at any depth, mixed-case variants exercise the case-folding path) and `MercuryError` (toString / toJSON never expose the response body, sentinel-based property). Recognised by OpenSSF Scorecard's `Fuzzing` check (8/10 → 10/10).
+- `release.yml`: now also emits `dist/index.js.intoto.jsonl` (SLSA in-toto attestation extracted from the Sigstore bundle's DSSE envelope, with non-null guard) alongside `dist/index.js.sigstore`. Lifts Scorecard's `Signed-Releases` check from 8/10 to 10/10.
+- `CONTINUITY.md`: project continuity plan with a fork-and-continue takeover checklist (Best Practices Silver: `access_continuity`).
+- `ASSURANCE_CASE.md`: threat model, trust boundaries, secure-design principles, CWE/OWASP weakness mapping (Best Practices Silver: `assurance_case`).
+- `SECURITY.md`: explicit "Security model — what you can and cannot expect" section; "Verifying releases" section with three independent paths (npm CLI provenance, `gh attestation verify`, `cosign verify-blob-attestation`).
+
+### Changed
+
+- `src/middleware.ts`: `SENSITIVE_KEYS` is now exported and `Object.freeze`d so the fuzz tests can reuse the canonical list (no drift) and the array is immutable at runtime.
 
 ## [0.6.2] - 2026-04-18
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { registerAllTools } from "./tools/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.6.2";
+export const VERSION = "0.7.0";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 export interface ServerOptions {


### PR DESCRIPTION
Promotes the [Unreleased] entries from PR #19 into a tagged 0.7.0:

  - **Fuzzing 0/10 → 10/10** (fast-check property tests)
  - **Signed-Releases 8/10 → 10/10** (.intoto.jsonl SLSA attestation)
  - **Best Practices Silver tier docs**: CONTINUITY.md, ASSURANCE_CASE.md, expanded SECURITY.md
  - `SENSITIVE_KEYS` exported + frozen

  Bumped to **minor** (0.7.0) — non-breaking but adds visible features (fuzz suite, SLSA attestation file shipped with releases) and 3 new top-level docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new documentation files covering continuity assurance, security, and verification procedures.
  * Enhanced test coverage documentation.

* **Chores**
  * Bumped version to 0.7.0 across package manifests and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->