### PR TITLE
docs(security): use --bundle <.sigstore> for cosign verify-blob-attes…

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -85,18 +85,25 @@ gh release download v<version> --repo klodr/mercury-invoicing-mcp --pattern 'ind
 gh attestation verify index.js --repo klodr/mercury-invoicing-mcp
 ```
 
-### 3. SLSA in-toto attestation — `cosign`
+### 3. Sigstore bundle (with embedded SLSA in-toto attestation) — `cosign`
 
-The `.intoto.jsonl` file in each release is a SLSA build provenance
-statement signed via Sigstore. Verify with [cosign](https://docs.sigstore.dev/cosign/installation/):
+The `index.js.sigstore` bundle is what `actions/attest-build-provenance`
+emits: a Sigstore-format bundle containing the DSSE-wrapped SLSA in-toto
+attestation plus the Fulcio certificate and the Rekor inclusion proof.
+That's the file [cosign](https://docs.sigstore.dev/cosign/installation/)
+wants for keyless verification:
 
 ```bash
 cosign verify-blob-attestation \
-  --signature index.js.intoto.jsonl \
+  --bundle index.js.sigstore \
   --certificate-identity-regexp '^https://github\.com/klodr/mercury-invoicing-mcp/' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   index.js
 ```
+
+The companion `index.js.intoto.jsonl` shipped in the same release is the
+DSSE envelope on its own, exposed for tools (like OpenSSF Scorecard's
+`Signed-Releases` check) that scan release assets by file extension.
 
 Any verification failure means the artifact was not built by the
 official release pipeline — do not install it.


### PR DESCRIPTION
…tation

The previous example used '--signature index.js.intoto.jsonl', which gives cosign only the DSSE envelope without the Fulcio cert chain or the Rekor inclusion proof — keyless verification cannot complete.

The Sigstore bundle file (.sigstore) is the canonical input for 'cosign verify-blob-attestation --bundle ...' and contains everything needed for keyless verification.

The .intoto.jsonl asset stays in the release, but is documented as the extension-driven format expected by OpenSSF Scorecard's Signed-Releases check, not as the cosign input.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated release verification instructions to validate releases using Sigstore bundles, which embed security proofs and certificates in a single file for streamlined verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->