### PR TITLE
Fix/cosign bundle flag

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -85,18 +85,25 @@ gh release download v<version> --repo klodr/mercury-invoicing-mcp --pattern 'ind
 gh attestation verify index.js --repo klodr/mercury-invoicing-mcp
 ```
 
-### 3. SLSA in-toto attestation — `cosign`
+### 3. Sigstore bundle (with embedded SLSA in-toto attestation) — `cosign`
 
-The `.intoto.jsonl` file in each release is a SLSA build provenance
-statement signed via Sigstore. Verify with [cosign](https://docs.sigstore.dev/cosign/installation/):
+The `index.js.sigstore` bundle is what `actions/attest-build-provenance`
+emits: a Sigstore-format bundle containing the DSSE-wrapped SLSA in-toto
+attestation plus the Fulcio certificate and the Rekor inclusion proof.
+That's the file [cosign](https://docs.sigstore.dev/cosign/installation/)
+wants for keyless verification:
 
 ```bash
 cosign verify-blob-attestation \
-  --signature index.js.intoto.jsonl \
+  --bundle index.js.sigstore \
   --certificate-identity-regexp '^https://github\.com/klodr/mercury-invoicing-mcp/' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   index.js
 ```
+
+The companion `index.js.intoto.jsonl` shipped in the same release is the
+DSSE envelope on its own, exposed for tools (like OpenSSF Scorecard's
+`Signed-Releases` check) that scan release assets by file extension.
 
 Any verification failure means the artifact was not built by the
 official release pipeline — do not install it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -144,6 +144,6 @@ This policy covers vulnerabilities in this repository's code (the MCP server its
 - **Never** commit your `MERCURY_API_KEY` to version control. Use environment variables or your MCP client's secret management.
 - Use **scoped tokens** with the minimum permissions you need.
 - Be aware that exposing write tools (send_money, create_invoice, etc.) to an LLM that processes untrusted content opens a prompt injection vector. Use read-only tokens or human-in-the-loop confirmation for write operations.
-- Keep this package updated; vulnerable versions will trigger Dependabot alerts on your projects.
+- Keep this package updated; vulnerable versions may trigger Dependabot alerts on projects that depend on it, provided Dependabot security updates are enabled for the consuming repository.
 
 Thanks for helping keep `mercury-invoicing-mcp` and its users safe.

--- a/scripts/sandbox-test.mjs
+++ b/scripts/sandbox-test.mjs
@@ -66,9 +66,9 @@ if (accId) {
 }
 await run("mercury_list_categories", "mercury_list_categories");
 await run("mercury_get_organization", "mercury_get_organization");
-const recipients = await run("mercury_list_recipients", "mercury_list_recipients");
+await run("mercury_list_recipients", "mercury_list_recipients");
 await run("mercury_get_treasury", "mercury_get_treasury");
-const trAccs = await run("mercury_list_treasury_transactions (existing tr ID)", "mercury_list_treasury_transactions", { accountId: "00000000-0000-0000-0000-000000000000" });
+await run("mercury_list_treasury_transactions (existing tr ID)", "mercury_list_treasury_transactions", { accountId: "00000000-0000-0000-0000-000000000000" });
 
 console.log("\n=== WRITES — BANKING ===");
 const newRec = await run("mercury_add_recipient (TEST)", "mercury_add_recipient", {


### PR DESCRIPTION
## Summary

  Three small fixes:

  1. `SECURITY.md` — switch the cosign verification example to `--bundle index.js.sigstore` (the actual Sigstore bundle file with cert chain + Rekor proof). The previous `--signature index.js.intoto.jsonl` path could not complete keyless
  verification because it lacked the cert chain. Same fix applied on faxdrop-mcp.
  2. `SECURITY.md` — soften the "vulnerable versions will trigger Dependabot alerts" line to "may trigger ... provided Dependabot security updates are enabled" (per CodeRabbit on faxdrop).
  3. `scripts/sandbox-test.mjs` — drop two unused `const` assignments flagged by CodeQL alerts #20 and #21.

  ## Test plan
  - [x] No code change in src/, tests still pass
  - [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security policy guidance to clarify when vulnerable versions may trigger Dependabot alerts in repositories that depend on this package, contingent on Dependabot security updates being enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->