### PR TITLE
fix(ci): use the actual commit SHA of v4.35.2, not the tag-object SHA

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,13 +34,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -40,6 +40,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
The previous bump pinned to 7fc6561…, which is the SHA of the annotated tag object on github/codeql-action, not the commit it points to. OpenSSF Scorecard's 'imposter commit' verification rejects it: "7fc6561… does not belong to github/codeql-action/ upload-sarif".

Dereference the tag object via:
  gh api repos/github/codeql-action/git/tags/7fc6561ed893d15cec696e062df840b21db27eb0

Real commit SHA for v4.35.2: 95e58e9a2cdfd71adc6e0353d5c52f41a045d225.

Same fix applied on klodr/faxdrop-mcp.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow versions for improved security scanning and code analysis infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->