### PR TITLE
polish: post-release verify workflow + EACCES doc (v0.7.5)

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -54,7 +54,7 @@ jobs:
           echo "Attestation URL: $ATT"
           mkdir verify-tmp && cd verify-tmp
           npm init -y >/dev/null
-          npm install --foreground-scripts --ignore-scripts "${PKG}@${VERSION}"
+          npm install --ignore-scripts "${PKG}@${VERSION}"
           npm audit signatures
 
       - name: Download signed assets from the GitHub Release

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -80,16 +80,23 @@ jobs:
           done
 
       - name: Path 2 — gh attestation verify
+        # Pin the signer workflow path AND the source ref so that an
+        # attestation produced by any other workflow in the repo (or by
+        # release.yml on a different ref) is rejected.
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh attestation verify verify-assets/index.js \
-            --repo "${{ github.repository }}"
+            --repo "${{ github.repository }}" \
+            --signer-workflow "${{ github.repository }}/.github/workflows/release.yml" \
+            --source-ref "refs/tags/${TAG}"
 
       - name: Path 3 — cosign verify-blob-attestation
+        # Same hardening: replace the open identity-regexp with the exact
+        # Fulcio SAN that release.yml at this tag would have produced.
         run: |
           cosign verify-blob-attestation \
             --bundle verify-assets/index.js.sigstore \
-            --certificate-identity-regexp '^https://github\.com/${{ github.repository }}/' \
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/release.yml@refs/tags/${TAG}" \
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
             verify-assets/index.js

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -1,0 +1,86 @@
+name: Verify published release
+
+# Runs after the publish job in release.yml has put the package on npm.
+# Exercises the three verification paths documented in SECURITY.md so we
+# catch any regression in the release pipeline (broken provenance, missing
+# Sigstore bundle, asset upload mismatch) within minutes of publish.
+on:
+  workflow_run:
+    workflows: ["Release & npm publish"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Re-run the three SECURITY.md verify paths
+    if: github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read         # gh release download
+      id-token: write        # cosign keyless verify (Fulcio cert chain)
+      attestations: read     # gh attestation verify
+    env:
+      PKG: mercury-invoicing-mcp
+      TAG: ${{ github.event.workflow_run.head_branch }}
+    steps:
+      - name: Setup Node 20
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.0.0
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Wait for npm to propagate the new version
+        run: |
+          VERSION="${TAG#v}"
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if [ "$(npm view "${PKG}@${VERSION}" version 2>/dev/null)" = "$VERSION" ]; then
+              echo "npm OK: ${PKG}@${VERSION}"
+              exit 0
+            fi
+            echo "Waiting for npm propagation... ($i/10)"
+            sleep 10
+          done
+          echo "Timeout waiting for npm to publish ${PKG}@${VERSION}" >&2
+          exit 1
+
+      - name: Path 1 — npm provenance via npm CLI
+        run: |
+          VERSION="${TAG#v}"
+          ATT=$(npm view "${PKG}@${VERSION}" --json | jq -er '.dist.attestations.url')
+          echo "Attestation URL: $ATT"
+          mkdir verify-tmp && cd verify-tmp
+          npm init -y >/dev/null
+          npm install --foreground-scripts --ignore-scripts "${PKG}@${VERSION}"
+          npm audit signatures
+
+      - name: Download signed assets from the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p verify-assets
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --pattern 'index.js' \
+            --pattern 'index.js.sigstore' \
+            --pattern 'index.js.intoto.jsonl' \
+            --dir verify-assets
+
+      - name: Path 2 — gh attestation verify
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh attestation verify verify-assets/index.js \
+            --repo "${{ github.repository }}"
+
+      - name: Path 3 — cosign verify-blob-attestation
+        run: |
+          cosign verify-blob-attestation \
+            --bundle verify-assets/index.js.sigstore \
+            --certificate-identity-regexp '^https://github\.com/${{ github.repository }}/' \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+            verify-assets/index.js

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -15,7 +15,13 @@ permissions:
 jobs:
   verify:
     name: Re-run the three SECURITY.md verify paths
-    if: github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')
+    # Only fire when the upstream workflow was triggered by a tag push
+    # (event == 'push'), succeeded, and the ref looks like a version tag.
+    # We re-validate the exact tag format in the first step below.
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      startsWith(github.event.workflow_run.head_branch, 'v')
     runs-on: ubuntu-latest
     permissions:
       contents: read         # gh release download
@@ -24,6 +30,18 @@ jobs:
       PKG: mercury-invoicing-mcp
       TAG: ${{ github.event.workflow_run.head_branch }}
     steps:
+      - name: Validate TAG format (semver, no shell metacharacters)
+        # head_branch is whatever ref triggered the upstream workflow. We
+        # already filtered on event=push and startsWith(v) at the job level,
+        # but TAG ends up in `cosign --certificate-identity ...@refs/tags/${TAG}`
+        # and in shell strings, so re-validate the bytes before they reach
+        # any subprocess. Reject anything that isn't strict semver.
+        run: |
+          if ! printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "ERROR: refusing to verify with TAG='$TAG' — not a semver tag" >&2
+            exit 1
+          fi
+
       - name: Setup Node 20
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.0.0
         with:
@@ -33,18 +51,24 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
-      - name: Wait for npm to propagate the new version
+      - name: Wait for npm to propagate the new version AND its attestations
+        # npm publishes in steps: version metadata → tarball → provenance
+        # attestations. Polling on .version alone races against
+        # .dist.attestations.url being still null when Path 1 runs.
         run: |
           VERSION="${TAG#v}"
           for i in 1 2 3 4 5 6 7 8 9 10; do
-            if [ "$(npm view "${PKG}@${VERSION}" version 2>/dev/null)" = "$VERSION" ]; then
-              echo "npm OK: ${PKG}@${VERSION}"
+            META=$(npm view "${PKG}@${VERSION}" --json 2>/dev/null || echo '{}')
+            VER_OK=$(printf '%s' "$META" | jq -r '.version // ""')
+            ATT_OK=$(printf '%s' "$META" | jq -r '.dist.attestations.url // ""')
+            if [ "$VER_OK" = "$VERSION" ] && [ -n "$ATT_OK" ]; then
+              echo "npm OK: ${PKG}@${VERSION} (attestations: $ATT_OK)"
               exit 0
             fi
-            echo "Waiting for npm propagation... ($i/10)"
+            echo "Waiting for ${PKG}@${VERSION} (version=$VER_OK, att=${ATT_OK:-<missing>}) — $i/10"
             sleep 10
           done
-          echo "Timeout waiting for npm to publish ${PKG}@${VERSION}" >&2
+          echo "Timeout waiting for ${PKG}@${VERSION} (version+attestations)" >&2
           exit 1
 
       - name: Path 1 — npm provenance via npm CLI

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -69,6 +69,16 @@ jobs:
             --pattern 'index.js.intoto.jsonl' \
             --dir verify-assets
 
+      - name: Assert all three release assets were actually downloaded
+        # gh release download silently skips missing patterns. We must fail
+        # fast if any of the three artifacts is absent — a missing
+        # .intoto.jsonl would mean Scorecard's Signed-Releases check drops
+        # back to 8/10 even though the rest of the verify steps still pass.
+        run: |
+          for f in index.js index.js.sigstore index.js.intoto.jsonl; do
+            test -f "verify-assets/$f" || { echo "ERROR: release asset missing: $f" >&2; exit 1; }
+          done
+
       - name: Path 2 — gh attestation verify
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -19,7 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read         # gh release download
-      id-token: write        # cosign keyless verify (Fulcio cert chain)
       attestations: read     # gh attestation verify
     env:
       PKG: mercury-invoicing-mcp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.5] - 2026-04-18
+
+### Added
+
+- **Post-release verification workflow** (`.github/workflows/verify-release.yml`):
+  re-exercises the three SECURITY.md verification paths (`npm audit signatures`,
+  `gh attestation verify`, `cosign verify-blob-attestation`) on every published
+  release. Runs on `workflow_run: completed` of `Release & npm publish` and
+  fails fast if provenance, the Sigstore bundle, or the attached release assets
+  drift. cosign installed via `sigstore/cosign-installer@v4.1.1` (SHA-pinned).
+
+### Documentation
+
+- `SECURITY.md`: extended the "single-process semantics" entry with an
+  explicit "persistent unreadable state" paragraph. On chronic `EACCES`/`EIO`
+  on the state file the middleware preserves the prior counter (does not
+  overwrite) and falls back to an in-memory cap valid for the current
+  process only — i.e. the cross-restart guarantee degrades to "cross-call
+  within one session". Mercury's server-side limits remain the load-bearing
+  control under that condition.
+
 ## [0.7.4] - 2026-04-18
 
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -106,7 +106,7 @@ Three independent ways to verify:
 ```bash
 # Verify the published tarball matches the GitHub release that built it
 npm view mercury-invoicing-mcp@<version> --json | jq .dist.attestations
-npm install --foreground-scripts --ignore-scripts mercury-invoicing-mcp@<version>
+npm install --ignore-scripts mercury-invoicing-mcp@<version>
 # or, for the strict provenance check:
 npm audit signatures
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,7 +46,16 @@ maintainer commits to, and limits that callers must account for.
   by the other process can be dropped, slightly under-counting against the
   per-day limit. Mercury's own server-side limits remain authoritative; for
   this MCP's local cap, treat the local rate-limit as best-effort under
-  concurrent-host conditions.
+  concurrent-host conditions. **Persistent unreadable state**: if the state
+  file becomes chronically unreadable mid-session (`EACCES`, `EIO`, broken
+  mount, container respawn without the volume), the middleware logs a
+  warning, refuses to overwrite the file (so the prior counter is
+  preserved), and falls back to an in-memory cap that lasts only for the
+  current process — i.e. the cross-restart guarantee degrades to "cross-call
+  within one session". An attacker able to make the file cyclically
+  unreadable (cron, container churn) effectively neutralises persistence.
+  Mercury's server-side limits remain the load-bearing control in that
+  scenario.
 
 ### What this MCP does NOT protect against
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { registerAllTools } from "./tools/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.7.4";
+export const VERSION = "0.7.5";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 export interface ServerOptions {


### PR DESCRIPTION
## Summary

Post-audit v2 polish (skipping the multi-process integration test as agreed — coverage/cost ratio not worth it).

1. **`.github/workflows/verify-release.yml`** — new workflow that triggers on `workflow_run: completed` of `Release & npm publish` and re-exercises the three SECURITY.md verification paths against the freshly-published artifact:
   - `npm audit signatures` (provenance)
   - `gh attestation verify` (GitHub OIDC chain)
   - `cosign verify-blob-attestation` (Sigstore bundle)
   Catches drift in provenance, Sigstore bundle or attached release assets within minutes of every publish. cosign installed via SHA-pinned `sigstore/cosign-installer@v4.1.1`.

2. **`SECURITY.md`** — new "persistent unreadable state" paragraph in the rate-limit section. On chronic `EACCES`/`EIO` on the state file the middleware preserves the prior counter (does not overwrite) and falls back to an in-memory cap valid for the current process only — i.e. the cross-restart guarantee degrades to "cross-call within one session". Mercury's server-side limits remain the load-bearing control.

## Test plan

- [x] `npm test` (94 tests pass)
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run build` clean
- [x] Workflow YAML syntactically valid (no jobs.<id> error)
- [ ] First post-release run on the v0.7.5 tag will be the real integration test

Bumps `0.7.4` → `0.7.5`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package/server version to 0.7.5
  * Added a post-release verification workflow that waits for published package propagation and validates published package signatures, attestations, and release assets; fails if propagation or verification times out

* **Documentation**
  * Added changelog entry for 0.7.5
  * Clarified rate-limit persistence when on-disk state is unreadable: preserves prior counter, falls back to in-memory per-process limits, defers to server-side limits for cross-restart protection; removed a redundant CLI flag in the example
<!-- end of auto-generated comment: release notes by coderabbit.ai -->