### PR TITLE
ci(verify-release): add --cert-identity for exact SAN match (v0.7.6)

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -104,16 +104,18 @@ jobs:
           done
 
       - name: Path 2 — gh attestation verify
-        # Pin the signer workflow path AND the source ref so that an
-        # attestation produced by any other workflow in the repo (or by
-        # release.yml on a different ref) is rejected.
+        # Pin the signer workflow path, the source ref, AND the exact
+        # Fulcio SAN. --signer-workflow alone matches the workflow file but
+        # not the ref encoded in the cert SAN; --cert-identity locks the
+        # full workflow@ref tuple, matching what cosign verifies in Path 3.
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh attestation verify verify-assets/index.js \
             --repo "${{ github.repository }}" \
             --signer-workflow "${{ github.repository }}/.github/workflows/release.yml" \
-            --source-ref "refs/tags/${TAG}"
+            --source-ref "refs/tags/${TAG}" \
+            --cert-identity "https://github.com/${{ github.repository }}/.github/workflows/release.yml@refs/tags/${TAG}"
 
       - name: Path 3 — cosign verify-blob-attestation
         # Same hardening: replace the open identity-regexp with the exact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.6] - 2026-04-18
+
+### Changed
+
+- `.github/workflows/verify-release.yml` — `gh attestation verify` now also
+  passes `--cert-identity` (in addition to `--signer-workflow` and
+  `--source-ref`) to lock the exact Fulcio SAN encoded in the attestation
+  certificate, matching what cosign verifies in Path 3. `--signer-workflow`
+  alone matches the workflow file but not the ref encoded in the SAN; the
+  added flag closes the last latitude.
+
 ## [0.7.5] - 2026-04-18
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { registerAllTools } from "./tools/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.7.5";
+export const VERSION = "0.7.6";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 export interface ServerOptions {


### PR DESCRIPTION
## Summary

Follow-up polish to PR #31 (CodeRabbit finding arrived after merge).

`gh attestation verify` now also passes `--cert-identity` (in addition to `--signer-workflow` and `--source-ref`) to lock the exact Fulcio SAN encoded in the attestation certificate, matching what cosign verifies in Path 3. `--signer-workflow` alone matches the workflow file but not the ref encoded in the SAN; the added flag closes the last latitude.

## Test plan

- [x] `npm test` (94 tests pass)
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] First post-release run on the v0.7.6 tag will be the real integration test

Bumps `0.7.5` → `0.7.6` (CI-only change, no code touched).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Release verification now enforces stricter certificate identity validation for attestations.

* **Chores**
  * Version bumped to 0.7.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->