### PR TITLE
ci(verify-release): pin npm install by tarball SHA-1 (v0.7.7)

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -73,24 +73,43 @@ jobs:
 
       - name: Path 1 — npm provenance via npm CLI
         # Scorecard's Pinned-Dependencies wants every npm install to be
-        # pinned by hash. We achieve that by downloading the tarball
-        # explicitly, verifying its SHA-1 against the registry-published
-        # shasum, then installing the local file. Equivalent install,
-        # but every byte that hits node_modules is hash-verified.
+        # pinned by hash. We download the tarball explicitly, verify both
+        # SHA-1 (.dist.shasum, legacy) AND SHA-512 SRI (.dist.integrity,
+        # current npm standard), then install the local file.
         run: |
           VERSION="${TAG#v}"
           META=$(npm view "${PKG}@${VERSION}" --json)
           ATT=$(echo "$META" | jq -er '.dist.attestations.url')
           TARBALL_URL=$(echo "$META" | jq -er '.dist.tarball')
           EXPECTED_SHA=$(echo "$META" | jq -er '.dist.shasum')
+          EXPECTED_INTEGRITY=$(echo "$META" | jq -er '.dist.integrity')
+          ALGO="${EXPECTED_INTEGRITY%%-*}"
+          EXPECTED_B64="${EXPECTED_INTEGRITY#*-}"
           echo "Attestation URL: $ATT"
-          echo "Tarball: $TARBALL_URL (expected sha1=$EXPECTED_SHA)"
+          echo "Tarball: $TARBALL_URL"
+          echo "Expected sha1=$EXPECTED_SHA"
+          echo "Expected $ALGO=$EXPECTED_B64"
           mkdir verify-tmp && cd verify-tmp
-          curl -sLO "$TARBALL_URL"
+          curl --fail --show-error --silent --location \
+               --retry 3 --retry-all-errors \
+               --connect-timeout 10 --max-time 120 \
+               -O "$TARBALL_URL"
           TARBALL=$(basename "$TARBALL_URL")
           ACTUAL_SHA=$(sha1sum "$TARBALL" | awk '{print $1}')
           if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
             echo "ERROR: tarball SHA-1 mismatch (expected $EXPECTED_SHA, got $ACTUAL_SHA)" >&2
+            exit 1
+          fi
+          case "$ALGO" in
+            sha512) ACTUAL_B64=$(sha512sum "$TARBALL" | awk '{print $1}' | xxd -r -p | base64 -w0) ;;
+            sha384) ACTUAL_B64=$(sha384sum "$TARBALL" | awk '{print $1}' | xxd -r -p | base64 -w0) ;;
+            sha256) ACTUAL_B64=$(sha256sum "$TARBALL" | awk '{print $1}' | xxd -r -p | base64 -w0) ;;
+            *) echo "ERROR: unsupported integrity algorithm: $ALGO" >&2; exit 1 ;;
+          esac
+          if [ "$ACTUAL_B64" != "$EXPECTED_B64" ]; then
+            echo "ERROR: tarball $ALGO integrity mismatch" >&2
+            echo "  expected: $EXPECTED_B64" >&2
+            echo "  actual:   $ACTUAL_B64" >&2
             exit 1
           fi
           npm init -y >/dev/null

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -72,13 +72,29 @@ jobs:
           exit 1
 
       - name: Path 1 — npm provenance via npm CLI
+        # Scorecard's Pinned-Dependencies wants every npm install to be
+        # pinned by hash. We achieve that by downloading the tarball
+        # explicitly, verifying its SHA-1 against the registry-published
+        # shasum, then installing the local file. Equivalent install,
+        # but every byte that hits node_modules is hash-verified.
         run: |
           VERSION="${TAG#v}"
-          ATT=$(npm view "${PKG}@${VERSION}" --json | jq -er '.dist.attestations.url')
+          META=$(npm view "${PKG}@${VERSION}" --json)
+          ATT=$(echo "$META" | jq -er '.dist.attestations.url')
+          TARBALL_URL=$(echo "$META" | jq -er '.dist.tarball')
+          EXPECTED_SHA=$(echo "$META" | jq -er '.dist.shasum')
           echo "Attestation URL: $ATT"
+          echo "Tarball: $TARBALL_URL (expected sha1=$EXPECTED_SHA)"
           mkdir verify-tmp && cd verify-tmp
+          curl -sLO "$TARBALL_URL"
+          TARBALL=$(basename "$TARBALL_URL")
+          ACTUAL_SHA=$(sha1sum "$TARBALL" | awk '{print $1}')
+          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            echo "ERROR: tarball SHA-1 mismatch (expected $EXPECTED_SHA, got $ACTUAL_SHA)" >&2
+            exit 1
+          fi
           npm init -y >/dev/null
-          npm install --ignore-scripts "${PKG}@${VERSION}"
+          npm install --ignore-scripts "./${TARBALL}"
           npm audit signatures
 
       - name: Download signed assets from the GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.7] - 2026-04-18
+
+### Changed
+
+- `.github/workflows/verify-release.yml` — Path 1 `npm install` now downloads
+  the tarball explicitly, verifies its SHA-1 against the registry-published
+  `dist.shasum`, and installs the local file (instead of `npm install
+  <pkg>@<version>`). Fixes Scorecard `Pinned-Dependencies` finding.
+  Functionally equivalent install (still `--ignore-scripts`), but every byte
+  that hits `node_modules` is hash-verified against registry metadata.
+  Symmetric to klodr/faxdrop-mcp v0.1.6.
+
 ## [0.7.6] - 2026-04-18
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { registerAllTools } from "./tools/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.7.6";
+export const VERSION = "0.7.7";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 export interface ServerOptions {


### PR DESCRIPTION
## Summary

Symmetric to klodr/faxdrop-mcp v0.1.6: fixes Scorecard `Pinned-Dependencies` finding by replacing `npm install <pkg>@<version>` with explicit tarball download + SHA-1 verify + local install.

Functionally equivalent install (still `--ignore-scripts`), but every byte that hits `node_modules` is hash-verified against registry metadata.

## Test plan
- [x] First post-release run on v0.7.7 will validate end-to-end

Bumps `0.7.6` → `0.7.7`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.7.7.
  * Release process improved: the workflow now explicitly downloads and verifies package tarballs against registry-published checksums before installation, aborting on mismatch to ensure byte-level integrity during release staging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->