### PR TITLE
ci(verify-release): manual ECDSA verify of npm registry signature (v0.7.8)

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -169,7 +169,7 @@ jobs:
             # Anything else (bad signature on a transitive registry dep,
             # network error, etc.) propagates and fails the job.
             if echo "$AUDIT_OUT" | grep -qiE \
-              '(^|[^[:alnum:]])(audited 0 packages|verified registry signatures of 0 packages|no packages with provenance to verify)[[:space:]]*$'; then
+              '^[[:space:]]*(audited 0 packages|verified registry signatures of 0 packages|no packages with provenance to verify)[[:space:]]*$'; then
               echo "npm audit signatures: nothing to verify on a local install — OK"
             else
               echo "ERROR: npm audit signatures failed (rc=$AUDIT_RC) with unrecognised output" >&2

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -123,7 +123,7 @@ jobs:
           KEYS_JSON=$(curl --fail --show-error --silent --max-time 30 \
                        --retry 3 --retry-all-errors \
                        https://registry.npmjs.org/-/npm/v1/keys)
-          PUBKEY_B64=$(echo "$KEYS_JSON" | jq -r ".keys[] | select(.keyid == \"$KEYID\") | .key")
+          PUBKEY_B64=$(echo "$KEYS_JSON" | jq -r --arg keyid "$KEYID" '.keys[] | select(.keyid == $keyid) | .key')
           if [ -z "$PUBKEY_B64" ]; then
             echo "ERROR: public key for keyid '$KEYID' not found in npm registry keys" >&2
             echo "Available keyids in /-/npm/v1/keys:" >&2

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -161,18 +161,22 @@ jobs:
           echo "$AUDIT_OUT"
           if [ "$AUDIT_RC" -ne 0 ]; then
             # Tolerate ONLY the exact phrases npm emits when the install
-            # has no registry-sourced packages to audit (which is the
-            # legitimate state after `npm install ./tarball.tgz`):
+            # has no registry-sourced packages to audit (legitimate state
+            # after `npm install ./tarball.tgz`):
             #   - "audited 0 packages in …"          (npm 10+)
             #   - "verified registry signatures of 0 packages"
             #   - "no packages with provenance to verify"
+            # We verify that EVERY non-blank line in the output matches one
+            # of those phrases, not just that one of them is present.
             # Anything else (bad signature on a transitive registry dep,
             # network error, etc.) propagates and fails the job.
-            if echo "$AUDIT_OUT" | grep -qiE \
-              '^[[:space:]]*(audited 0 packages( in .*)?|verified registry signatures of 0 packages|no packages with provenance to verify)[[:space:]]*$'; then
+            ALLOWED='^[[:space:]]*(audited 0 packages( in .*)?|verified registry signatures of 0 packages|no packages with provenance to verify)[[:space:]]*$'
+            NON_ALLOWED=$(echo "$AUDIT_OUT" | grep -vE '^[[:space:]]*$' | grep -ivE "$ALLOWED" || true)
+            if [ -z "$NON_ALLOWED" ]; then
               echo "npm audit signatures: nothing to verify on a local install — OK"
             else
-              echo "ERROR: npm audit signatures failed (rc=$AUDIT_RC) with unrecognised output" >&2
+              echo "ERROR: npm audit signatures failed (rc=$AUDIT_RC) with unrecognised lines:" >&2
+              echo "$NON_ALLOWED" >&2
               exit "$AUDIT_RC"
             fi
           fi

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -152,45 +152,15 @@ jobs:
             exit 1
           fi
           echo "npm registry signature: OK ($KEYID)"
-
-          # The local-tarball install satisfies Pinned-Dependencies. The
-          # registry-side signature was already verified above. We still
-          # invoke `npm audit signatures` for defence-in-depth, but a local
-          # install legitimately has nothing to audit registry-side; only
-          # tolerate exit codes that say exactly that, propagate everything
-          # else.
-          npm init -y >/dev/null
-          npm install --ignore-scripts "./${TARBALL}"
-          set +e
-          AUDIT_OUT=$(npm audit signatures 2>&1)
-          AUDIT_RC=$?
-          set -e
-          echo "$AUDIT_OUT"
-          # Parse the audit output strictly. Allowed phrases (npm's
-          # nothing-to-audit case after a local-tarball install):
-          #   - "audited 0 packages in …"          (npm 10+)
-          #   - "verified registry signatures of 0 packages"
-          #   - "no packages with provenance to verify"
-          # Every non-blank line MUST match one of those, otherwise the job
-          # fails (catches bad signatures on transitive registry deps,
-          # network errors, etc.). We also fail on rc != 0 with empty
-          # output (silent crash).
-          ALLOWED='^[[:space:]]*(audited 0 packages([[:space:]]in[[:space:]][0-9]+(\.[0-9]+)?(ms|s))?|verified registry signatures of 0 packages|no packages with provenance to verify)[[:space:]]*$'
-          NON_ALLOWED=$(echo "$AUDIT_OUT" | grep -vE '^[[:space:]]*$' | grep -ivE "$ALLOWED" || true)
-          if [ -n "$NON_ALLOWED" ]; then
-            echo "ERROR: npm audit signatures had unrecognised lines (rc=$AUDIT_RC):" >&2
-            echo "$NON_ALLOWED" >&2
-            # Force non-zero exit even if npm itself returned 0 — the
-            # presence of any non-allowed line is itself a failure.
-            rc="${AUDIT_RC:-0}"
-            [ "$rc" -eq 0 ] && rc=1
-            exit "$rc"
-          fi
-          if [ "$AUDIT_RC" -ne 0 ] && [ -z "$(echo "$AUDIT_OUT" | tr -d '[:space:]')" ]; then
-            echo "ERROR: npm audit signatures returned rc=$AUDIT_RC with empty output" >&2
-            exit "$AUDIT_RC"
-          fi
-          echo "npm audit signatures: OK (rc=$AUDIT_RC)"
+          echo "Path 1 OK: SHA-1 + SHA-512 SRI + ECDSA registry signature all matched."
+          # NB: no `npm install` / `npm audit signatures` step. Everything
+          # `npm audit signatures` would have checked is already done above
+          # (and more strictly): the tarball bytes are SHA-512 verified
+          # against `dist.integrity`, and the registry's ECDSA signature on
+          # `<pkg>@<version>:<integrity>` is verified by hand against the
+          # public keys at /-/npm/v1/keys. Skipping the install also keeps
+          # Scorecard's Pinned-Dependencies check clean (no `npm install`
+          # invocation in the workflow at all).
 
       - name: Download signed assets from the GitHub Release
         env:

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -164,27 +164,27 @@ jobs:
           AUDIT_RC=$?
           set -e
           echo "$AUDIT_OUT"
-          if [ "$AUDIT_RC" -ne 0 ]; then
-            # Tolerate ONLY the exact phrases npm emits when the install
-            # has no registry-sourced packages to audit (legitimate state
-            # after `npm install ./tarball.tgz`):
-            #   - "audited 0 packages in …"          (npm 10+)
-            #   - "verified registry signatures of 0 packages"
-            #   - "no packages with provenance to verify"
-            # We verify that EVERY non-blank line in the output matches one
-            # of those phrases, not just that one of them is present.
-            # Anything else (bad signature on a transitive registry dep,
-            # network error, etc.) propagates and fails the job.
-            ALLOWED='^[[:space:]]*(audited 0 packages( in .*)?|verified registry signatures of 0 packages|no packages with provenance to verify)[[:space:]]*$'
-            NON_ALLOWED=$(echo "$AUDIT_OUT" | grep -vE '^[[:space:]]*$' | grep -ivE "$ALLOWED" || true)
-            if [ -z "$NON_ALLOWED" ]; then
-              echo "npm audit signatures: nothing to verify on a local install — OK"
-            else
-              echo "ERROR: npm audit signatures failed (rc=$AUDIT_RC) with unrecognised lines:" >&2
-              echo "$NON_ALLOWED" >&2
-              exit "$AUDIT_RC"
-            fi
+          # Parse the audit output strictly. Allowed phrases (npm's
+          # nothing-to-audit case after a local-tarball install):
+          #   - "audited 0 packages in …"          (npm 10+)
+          #   - "verified registry signatures of 0 packages"
+          #   - "no packages with provenance to verify"
+          # Every non-blank line MUST match one of those, otherwise the job
+          # fails (catches bad signatures on transitive registry deps,
+          # network errors, etc.). We also fail on rc != 0 with empty
+          # output (silent crash).
+          ALLOWED='^[[:space:]]*(audited 0 packages( in .*)?|verified registry signatures of 0 packages|no packages with provenance to verify)[[:space:]]*$'
+          NON_ALLOWED=$(echo "$AUDIT_OUT" | grep -vE '^[[:space:]]*$' | grep -ivE "$ALLOWED" || true)
+          if [ -n "$NON_ALLOWED" ]; then
+            echo "ERROR: npm audit signatures had unrecognised lines (rc=$AUDIT_RC):" >&2
+            echo "$NON_ALLOWED" >&2
+            exit "${AUDIT_RC:-1}"
           fi
+          if [ "$AUDIT_RC" -ne 0 ] && [ -z "$(echo "$AUDIT_OUT" | tr -d '[:space:]')" ]; then
+            echo "ERROR: npm audit signatures returned rc=$AUDIT_RC with empty output" >&2
+            exit "$AUDIT_RC"
+          fi
+          echo "npm audit signatures: OK (rc=$AUDIT_RC)"
 
       - name: Download signed assets from the GitHub Release
         env:

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -169,7 +169,7 @@ jobs:
             # Anything else (bad signature on a transitive registry dep,
             # network error, etc.) propagates and fails the job.
             if echo "$AUDIT_OUT" | grep -qiE \
-              '^[[:space:]]*(audited 0 packages|verified registry signatures of 0 packages|no packages with provenance to verify)[[:space:]]*$'; then
+              '^[[:space:]]*(audited 0 packages( in .*)?|verified registry signatures of 0 packages|no packages with provenance to verify)[[:space:]]*$'; then
               echo "npm audit signatures: nothing to verify on a local install — OK"
             else
               echo "ERROR: npm audit signatures failed (rc=$AUDIT_RC) with unrecognised output" >&2

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -112,9 +112,41 @@ jobs:
             echo "  actual:   $ACTUAL_B64" >&2
             exit 1
           fi
+
+          # ECDSA P-256 verification of the npm registry signature on
+          # "<pkg>@<version>:<integrity>". `npm audit signatures` would do
+          # this for us, but it requires a registry-resolved install (which
+          # would defeat Scorecard's Pinned-Dependencies check). So we do it
+          # by hand against the public keys at /-/npm/v1/keys.
+          KEYID=$(echo "$META" | jq -er '.dist.signatures[0].keyid')
+          SIG_B64=$(echo "$META" | jq -er '.dist.signatures[0].sig')
+          KEYS_JSON=$(curl --fail --show-error --silent --max-time 30 \
+                       --retry 3 --retry-all-errors \
+                       https://registry.npmjs.org/-/npm/v1/keys)
+          PUBKEY_B64=$(echo "$KEYS_JSON" | jq -er ".keys[] | select(.keyid == \"$KEYID\") | .key")
+          {
+            echo "-----BEGIN PUBLIC KEY-----"
+            echo "$PUBKEY_B64" | fold -w 64
+            echo "-----END PUBLIC KEY-----"
+          } > npm-pubkey.pem
+          echo "$SIG_B64" | base64 -d > npm-sig.bin
+          SIGNED_MSG="${PKG}@${VERSION}:${EXPECTED_INTEGRITY}"
+          if ! echo -n "$SIGNED_MSG" | openssl dgst -sha256 \
+                  -verify npm-pubkey.pem -signature npm-sig.bin; then
+            echo "ERROR: npm registry ECDSA signature verification failed" >&2
+            echo "  keyid:   $KEYID" >&2
+            echo "  message: $SIGNED_MSG" >&2
+            exit 1
+          fi
+          echo "npm registry signature: OK ($KEYID)"
+
+          # The local-tarball install satisfies Pinned-Dependencies. The
+          # registry-side signature was already verified above; npm audit
+          # signatures here is defence-in-depth (it's a no-op on a local
+          # install, but kept for symmetry with the documented flow).
           npm init -y >/dev/null
           npm install --ignore-scripts "./${TARBALL}"
-          npm audit signatures
+          npm audit signatures || true
 
       - name: Download signed assets from the GitHub Release
         env:

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -147,12 +147,27 @@ jobs:
           echo "npm registry signature: OK ($KEYID)"
 
           # The local-tarball install satisfies Pinned-Dependencies. The
-          # registry-side signature was already verified above; npm audit
-          # signatures here is defence-in-depth (it's a no-op on a local
-          # install, but kept for symmetry with the documented flow).
+          # registry-side signature was already verified above. We still
+          # invoke `npm audit signatures` for defence-in-depth, but a local
+          # install legitimately has nothing to audit registry-side; only
+          # tolerate exit codes that say exactly that, propagate everything
+          # else.
           npm init -y >/dev/null
           npm install --ignore-scripts "./${TARBALL}"
-          npm audit signatures || true
+          set +e
+          AUDIT_OUT=$(npm audit signatures 2>&1)
+          AUDIT_RC=$?
+          set -e
+          echo "$AUDIT_OUT"
+          if [ "$AUDIT_RC" -ne 0 ]; then
+            # Local-tarball / no-registry-source case: npm reports nothing to audit
+            if echo "$AUDIT_OUT" | grep -qiE "no signatures|nothing to audit|0 packages|no packages with signatures|did not find any registry"; then
+              echo "npm audit signatures: nothing to verify on a local install — OK"
+            else
+              echo "ERROR: npm audit signatures failed (rc=$AUDIT_RC) with unrecognised output" >&2
+              exit "$AUDIT_RC"
+            fi
+          fi
 
       - name: Download signed assets from the GitHub Release
         env:

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -169,7 +169,7 @@ jobs:
             # Anything else (bad signature on a transitive registry dep,
             # network error, etc.) propagates and fails the job.
             if echo "$AUDIT_OUT" | grep -qiE \
-              '(^|[^[:alnum:]])(audited 0 packages|verified registry signatures of 0 packages|no packages with provenance to verify)'; then
+              '(^|[^[:alnum:]])(audited 0 packages|verified registry signatures of 0 packages|no packages with provenance to verify)[[:space:]]*$'; then
               echo "npm audit signatures: nothing to verify on a local install — OK"
             else
               echo "ERROR: npm audit signatures failed (rc=$AUDIT_RC) with unrecognised output" >&2

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -173,7 +173,7 @@ jobs:
           # fails (catches bad signatures on transitive registry deps,
           # network errors, etc.). We also fail on rc != 0 with empty
           # output (silent crash).
-          ALLOWED='^[[:space:]]*(audited 0 packages( in .*)?|verified registry signatures of 0 packages|no packages with provenance to verify)[[:space:]]*$'
+          ALLOWED='^[[:space:]]*(audited 0 packages([[:space:]]in[[:space:]][0-9]+(\.[0-9]+)?(ms|s))?|verified registry signatures of 0 packages|no packages with provenance to verify)[[:space:]]*$'
           NON_ALLOWED=$(echo "$AUDIT_OUT" | grep -vE '^[[:space:]]*$' | grep -ivE "$ALLOWED" || true)
           if [ -n "$NON_ALLOWED" ]; then
             echo "ERROR: npm audit signatures had unrecognised lines (rc=$AUDIT_RC):" >&2

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -144,7 +144,7 @@ jobs:
           } > npm-pubkey.pem
           echo "$SIG_B64" | base64 -d > npm-sig.bin
           SIGNED_MSG="${PKG}@${VERSION}:${EXPECTED_INTEGRITY}"
-          if ! echo -n "$SIGNED_MSG" | openssl dgst -sha256 \
+          if ! printf '%s' "$SIGNED_MSG" | openssl dgst -sha256 \
                   -verify npm-pubkey.pem -signature npm-sig.bin; then
             echo "ERROR: npm registry ECDSA signature verification failed" >&2
             echo "  keyid:   $KEYID" >&2

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -178,7 +178,11 @@ jobs:
           if [ -n "$NON_ALLOWED" ]; then
             echo "ERROR: npm audit signatures had unrecognised lines (rc=$AUDIT_RC):" >&2
             echo "$NON_ALLOWED" >&2
-            exit "${AUDIT_RC:-1}"
+            # Force non-zero exit even if npm itself returned 0 — the
+            # presence of any non-allowed line is itself a failure.
+            rc="${AUDIT_RC:-0}"
+            [ "$rc" -eq 0 ] && rc=1
+            exit "$rc"
           fi
           if [ "$AUDIT_RC" -ne 0 ] && [ -z "$(echo "$AUDIT_OUT" | tr -d '[:space:]')" ]; then
             echo "ERROR: npm audit signatures returned rc=$AUDIT_RC with empty output" >&2

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -53,22 +53,24 @@ jobs:
 
       - name: Wait for npm to propagate the new version AND its attestations
         # npm publishes in steps: version metadata → tarball → provenance
-        # attestations. Polling on .version alone races against
-        # .dist.attestations.url being still null when Path 1 runs.
+        # attestations → registry signatures. Polling on .version alone
+        # races against .dist.attestations.url or .dist.signatures still
+        # being absent when Path 1 runs. Wait for all three.
         run: |
           VERSION="${TAG#v}"
           for i in 1 2 3 4 5 6 7 8 9 10; do
             META=$(npm view "${PKG}@${VERSION}" --json 2>/dev/null || echo '{}')
             VER_OK=$(printf '%s' "$META" | jq -r '.version // ""')
             ATT_OK=$(printf '%s' "$META" | jq -r '.dist.attestations.url // ""')
-            if [ "$VER_OK" = "$VERSION" ] && [ -n "$ATT_OK" ]; then
-              echo "npm OK: ${PKG}@${VERSION} (attestations: $ATT_OK)"
+            SIG_OK=$(printf '%s' "$META" | jq -r '.dist.signatures | length // 0')
+            if [ "$VER_OK" = "$VERSION" ] && [ -n "$ATT_OK" ] && [ "${SIG_OK:-0}" -ge 1 ]; then
+              echo "npm OK: ${PKG}@${VERSION} (attestations: $ATT_OK, signatures: $SIG_OK)"
               exit 0
             fi
-            echo "Waiting for ${PKG}@${VERSION} (version=$VER_OK, att=${ATT_OK:-<missing>}) — $i/10"
+            echo "Waiting for ${PKG}@${VERSION} (version=$VER_OK, att=${ATT_OK:-<missing>}, sigs=${SIG_OK:-0}) — $i/10"
             sleep 10
           done
-          echo "Timeout waiting for ${PKG}@${VERSION} (version+attestations)" >&2
+          echo "Timeout waiting for ${PKG}@${VERSION} (version+attestations+signatures)" >&2
           exit 1
 
       - name: Path 1 — npm provenance via npm CLI

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -123,7 +123,13 @@ jobs:
           KEYS_JSON=$(curl --fail --show-error --silent --max-time 30 \
                        --retry 3 --retry-all-errors \
                        https://registry.npmjs.org/-/npm/v1/keys)
-          PUBKEY_B64=$(echo "$KEYS_JSON" | jq -er ".keys[] | select(.keyid == \"$KEYID\") | .key")
+          PUBKEY_B64=$(echo "$KEYS_JSON" | jq -r ".keys[] | select(.keyid == \"$KEYID\") | .key")
+          if [ -z "$PUBKEY_B64" ]; then
+            echo "ERROR: public key for keyid '$KEYID' not found in npm registry keys" >&2
+            echo "Available keyids in /-/npm/v1/keys:" >&2
+            echo "$KEYS_JSON" | jq -r '.keys[].keyid' >&2
+            exit 1
+          fi
           {
             echo "-----BEGIN PUBLIC KEY-----"
             echo "$PUBKEY_B64" | fold -w 64

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -169,7 +169,7 @@ jobs:
             # Anything else (bad signature on a transitive registry dep,
             # network error, etc.) propagates and fails the job.
             if echo "$AUDIT_OUT" | grep -qiE \
-              '(^|[^[:alnum:]])audited 0 packages|verified registry signatures of 0 packages|no packages with provenance to verify'; then
+              '(^|[^[:alnum:]])(audited 0 packages|verified registry signatures of 0 packages|no packages with provenance to verify)'; then
               echo "npm audit signatures: nothing to verify on a local install — OK"
             else
               echo "ERROR: npm audit signatures failed (rc=$AUDIT_RC) with unrecognised output" >&2

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -118,6 +118,11 @@ jobs:
           # this for us, but it requires a registry-resolved install (which
           # would defeat Scorecard's Pinned-Dependencies check). So we do it
           # by hand against the public keys at /-/npm/v1/keys.
+          SIG_COUNT=$(echo "$META" | jq -r '.dist.signatures | length // 0')
+          if [ "${SIG_COUNT:-0}" -lt 1 ]; then
+            echo "ERROR: no .dist.signatures on ${PKG}@${VERSION} (npm registry didn't sign — refusing to proceed)" >&2
+            exit 1
+          fi
           KEYID=$(echo "$META" | jq -er '.dist.signatures[0].keyid')
           SIG_B64=$(echo "$META" | jq -er '.dist.signatures[0].sig')
           KEYS_JSON=$(curl --fail --show-error --silent --max-time 30 \

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -160,8 +160,16 @@ jobs:
           set -e
           echo "$AUDIT_OUT"
           if [ "$AUDIT_RC" -ne 0 ]; then
-            # Local-tarball / no-registry-source case: npm reports nothing to audit
-            if echo "$AUDIT_OUT" | grep -qiE "no signatures|nothing to audit|0 packages|no packages with signatures|did not find any registry"; then
+            # Tolerate ONLY the exact phrases npm emits when the install
+            # has no registry-sourced packages to audit (which is the
+            # legitimate state after `npm install ./tarball.tgz`):
+            #   - "audited 0 packages in …"          (npm 10+)
+            #   - "verified registry signatures of 0 packages"
+            #   - "no packages with provenance to verify"
+            # Anything else (bad signature on a transitive registry dep,
+            # network error, etc.) propagates and fails the job.
+            if echo "$AUDIT_OUT" | grep -qiE \
+              '(^|[^[:alnum:]])audited 0 packages|verified registry signatures of 0 packages|no packages with provenance to verify'; then
               echo "npm audit signatures: nothing to verify on a local install — OK"
             else
               echo "ERROR: npm audit signatures failed (rc=$AUDIT_RC) with unrecognised output" >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.8] - 2026-04-18
+
+### Changed
+
+- `.github/workflows/verify-release.yml` — added manual ECDSA P-256 verification
+  of the npm registry signature on `<pkg>@<version>:<integrity>` against the
+  public keys at `https://registry.npmjs.org/-/npm/v1/keys`. Closes the gap
+  introduced in 0.7.7 where the local-tarball install bypassed
+  `npm audit signatures` registry-side check (a registry-based install
+  would have re-tripped Scorecard's Pinned-Dependencies). Per CodeRabbit
+  on PR #33.
+
 ## [0.7.7] - 2026-04-18
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { registerAllTools } from "./tools/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.7.7";
+export const VERSION = "0.7.8";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 export interface ServerOptions {


### PR DESCRIPTION
## Summary

Follow-up to v0.7.7 (PR #33). CodeRabbit pointed out that local-tarball `npm install` bypasses `npm audit signatures` registry-side check.

Fix: manual ECDSA P-256 verification of the npm registry signature on `<pkg>@<version>:<integrity>` against the public keys at `https://registry.npmjs.org/-/npm/v1/keys`. We can't switch to a registry-based install (Scorecard would re-flag Pinned-Dependencies).

Flow:
1. Pull `.dist.signatures[0].{keyid,sig}` from `npm view --json`
2. Fetch public keys from npm registry
3. Build canonical signed message `<pkg>@<version>:<integrity>`
4. `openssl dgst -sha256 -verify ...` — fail-closed

## Test plan
- [x] Local syntax check
- [ ] First post-release run on v0.7.8 will validate end-to-end

Bumps `0.7.7` → `0.7.8`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit ECDSA P-256 verification of published packages against registry public keys to strengthen release integrity checks.
  * Release verification now requires package version, attestations URL, and at least one registry signature before proceeding; improved timeout/log messages to reflect signature checks.

* **Chores**
  * Bumped package/server version to 0.7.8.

* **Documentation**
  * Added CHANGELOG entry for 0.7.8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->