### PR TITLE
fix(verify-release): drop --signer-workflow (mutually exclusive with --cert-identity)

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -185,16 +185,15 @@ jobs:
           done
 
       - name: Path 2 — gh attestation verify
-        # Pin the signer workflow path, the source ref, AND the exact
-        # Fulcio SAN. --signer-workflow alone matches the workflow file but
-        # not the ref encoded in the cert SAN; --cert-identity locks the
-        # full workflow@ref tuple, matching what cosign verifies in Path 3.
+        # Pin the exact Fulcio SAN (workflow path + ref) and the source ref.
+        # --cert-identity is mutually exclusive with --signer-workflow in the
+        # current gh CLI: the cert-identity already encodes the workflow path
+        # AND the tag ref, so it is strictly more specific.
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh attestation verify verify-assets/index.js \
             --repo "${{ github.repository }}" \
-            --signer-workflow "${{ github.repository }}/.github/workflows/release.yml" \
             --source-ref "refs/tags/${TAG}" \
             --cert-identity "https://github.com/${{ github.repository }}/.github/workflows/release.yml@refs/tags/${TAG}"
 


### PR DESCRIPTION
## Summary

The current `gh attestation verify` CLI rejects passing both `--signer-workflow` and `--cert-identity` (the flag group `[cert-identity, cert-identity-regex, signer-repo, signer-workflow]` is mutually exclusive).

The v0.7.8 release-verify run failed with:

```
if any flags in the group [cert-identity cert-identity-regex signer-repo signer-workflow]
are set none of the others can be; [cert-identity signer-workflow] were all set
Error: Process completed with exit code 1.
```

`--cert-identity` is strictly more specific (encodes both the workflow path and the tag ref in the Fulcio SAN), so we keep it and drop `--signer-workflow`. Comment updated to explain the mutual exclusion.

## Root cause

Pre-existing bug introduced in commit `9fddc33a` (the cert-identity polish PR): I added `--cert-identity` next to the existing `--signer-workflow` instead of replacing it. The verify-release job has been failing with exit 1 — without performing any actual verification — on every release since.

## Why a separate PR

Hot-fix detached from PR #35 (`drop-node-18+jest`) which is BREAKING and will take longer to review. Repairing the release pipeline shouldn't wait.

## Test plan

- [ ] CI — only the lint/build/test checks run on this PR (verify-release fires on `workflow_run` from a tag push, not on PRs).
- [ ] Real validation will happen on the next tag push (v0.8.0 from PR #35 once merged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release verification workflow to refine attestation validation mechanisms, optimizing the security verification process for release artifacts while maintaining integrity guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->