### PR TITLE
chore(release): v0.7.9 — verify-release CLI flag fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.9] - 2026-04-19
+
+### Fixed
+
+- `.github/workflows/verify-release.yml` — drop `--signer-workflow` from
+  `gh attestation verify` (Path 2). The current `gh` CLI rejects the
+  combination with `--cert-identity` (mutually exclusive flag group),
+  so the post-release verify job exited 1 on every release since 0.7.6
+  without performing any actual verification. `--cert-identity` is
+  strictly more specific (encodes both the workflow path and the tag
+  ref in the Fulcio SAN), so we keep it and drop `--signer-workflow`.
+  Symmetric to klodr/faxdrop-mcp v0.1.9.
+
 ## [0.7.8] - 2026-04-18
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { registerAllTools } from "./tools/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.7.8";
+export const VERSION = "0.7.9";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 export interface ServerOptions {


### PR DESCRIPTION
## Summary

Patch release shipping the fix from #36 so the verify-release pipeline actually runs on the next tag push. No user-facing change.

After merge, the v0.7.9 tag will be cut on the merge commit so `release.yml` + `verify-release.yml` can both fire end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed post-release verification workflow that was exiting with code 1 without performing verification since v0.7.6. Resolved a configuration conflict in the release verification process to ensure proper completion and enable accurate artifact verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->