### PR TITLE
ci(codecov): revert project threshold to 0.5% (post-v0.8.0 baseline)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `codecov.yml`: revert `project.threshold` from `1.5%` to `0.5%` now that
+  v0.8.0 has shipped and codecov has a clean v8-instrumented baseline.
+  The 1.5% was a one-shot accommodation for the istanbul → v8
+  instrumentation switch; PRs from here on compare like-for-like.
+  Patch threshold (`95%` / `1.5%`) is unchanged.
+
 ## [0.8.0] - 2026-04-19
 
 ### Security

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,23 +3,16 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 1.5%
-        # TODO(post-v0.8.0): revert `threshold` to 0.5% once the first v8-
-        # instrumented release has landed on main and codecov has a clean
-        # baseline. The 1.5% (vs the historical 0.5%) is a one-shot
-        # accommodation for the istanbul → v8 instrumentation switch in
-        # the jest → vitest migration: v8 splits some ternary/optional
-        # branches that istanbul collapsed, surfacing ~7 "partials" with
-        # no real loss of code coverage. Project coverage shouldn't drop
-        # more than 1.5% in any single PR until then.
+        threshold: 0.5%
+        # Project coverage shouldn't drop more than 0.5% in any single PR.
     patch:
       default:
         target: 95%
         threshold: 1.5%
         # Strict patch gate (95% target, 1.5% threshold) — new code must
         # be ≥93.5% covered. The 1.5% threshold (vs an absolute 95%
-        # requirement, and aligned with the project threshold above)
-        # exists for two narrow exceptions, not a blanket relaxation:
+        # requirement) exists for two narrow exceptions, not a blanket
+        # relaxation:
         # - Defensive code paths (e.g. TOCTOU re-checks, OS-level error
         #   branches) are intentionally hard to exercise in unit tests.
         # - Pure-formatting PRs (Prettier reflows, ESLint cleanups)


### PR DESCRIPTION
## Summary

Now that v0.8.0 has shipped (with the jest → vitest / istanbul → v8 migration), codecov has a clean v8 baseline and the 1.5% accommodation is no longer needed. PRs from here on compare like-for-like.

- `project.threshold`: 1.5% → 0.5% (back to historical strictness, fulfilling the `TODO(post-v0.8.0)` from #35).
- `patch`: unchanged (95% target / 1.5% threshold — deliberate stricter setting, kept).

Symmetric to klodr/faxdrop-mcp (PR opened in parallel).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted code coverage thresholds in continuous integration configuration to optimize project quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->