### PR TITLE
chore(socket): silence intrinsic-behavior alerts (false instead of true)

### DIFF
--- a/socket.yml
+++ b/socket.yml
@@ -19,16 +19,18 @@ githubApp:
   secretAlertsEnabled: true
 
 issueRules:
-  # Legitimate behaviour for a Mercury Banking client — accepted, not a finding.
-  # Each is documented in README.md (see Configuration / Security sections).
-  envVars: true
-  filesystemAccess: true
-  networkAccess: true
-  urlStrings: true
-  hasIPProxy: true
+  # Silence the alerts that are intrinsic to what this MCP does (read env,
+  # read local rate-limit state, call the Mercury Banking API, hardcode the
+  # Mercury production / sandbox URLs). Each is intentional and documented
+  # in README.md (Configuration / Security sections).
+  envVars: false
+  filesystemAccess: false
+  networkAccess: false
+  urlStrings: false
+  hasIPProxy: false
 
-  # Transitive deps from @modelcontextprotocol/sdk → express. Not actionable
-  # from this package. Tracked upstream:
+  # Silence noise from transitive deps via @modelcontextprotocol/sdk → express.
+  # Not actionable from this package. Tracked upstream:
   #   https://github.com/modelcontextprotocol/typescript-sdk/issues/1924
   gptDidYouMean: false
   unstableOwnership: false


### PR DESCRIPTION
## Summary

The previous `envVars / filesystemAccess / networkAccess / urlStrings / hasIPProxy: true` values were inverted vs Socket's semantics: those rules are NOT in Socket's default-enabled set, so `true` actively OPTS IN to the alerts instead of acknowledging legitimate behavior.

Flip them to `false` so the Socket dashboard stops surfacing noise that's already documented in README.md.

Symmetric to klodr/faxdrop-mcp (same fix on the hardening branch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security alert configuration to refine legitimate behavior detection for environment variables, file system access, network operations, URL identification, and proxy detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->