### PR TITLE
Release v0.8.1 — codecov baseline + socket.yml flip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-04-19
+
 ### Changed
 
 - `codecov.yml`: revert `project.threshold` from `1.5%` to `0.5%` now that
@@ -14,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The 1.5% was a one-shot accommodation for the istanbul → v8
   instrumentation switch; PRs from here on compare like-for-like.
   Patch threshold (`95%` / `1.5%`) is unchanged.
+- `socket.yml`: flip the intrinsic-behavior alerts (`envVars`,
+  `filesystemAccess`, `networkAccess`, `urlStrings`, `hasIPProxy`) from
+  `true` to `false`. These rules aren't in Socket's default-enabled set,
+  so the previous `true` opted us IN to the warnings instead of silencing
+  them. The behaviors themselves (env-var reads, fetch calls, etc.) are
+  intentional for an MCP server that talks to an external API.
 
 ## [0.8.0] - 2026-04-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { registerAllTools } from "./tools/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.8.0";
+export const VERSION = "0.8.1";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 export interface ServerOptions {


### PR DESCRIPTION
## Summary
- Promote the Unreleased section to **[0.8.1]** in CHANGELOG.
- Bump `package.json`, `package-lock.json`, `server.json`, `src/server.ts` to 0.8.1.

## What ships in 0.8.1
Two post-0.8.0 hygiene PRs already on `main`:
- #38 — codecov `project.threshold` 1.5% → 0.5% (drop the one-shot istanbul→v8 accommodation).
- #39 — socket.yml flip (intrinsic-behavior alerts: `envVars`, `filesystemAccess`, `networkAccess`, `urlStrings`, `hasIPProxy` from `true` to `false`).

Patch bump — no behavior change to the tool surface.

## Test plan
- [x] `npx vitest run` — 100/100
- [x] `npm run build` — dist 34.84 KB
- [x] `npm run lint` — clean
- [ ] CI: required checks pass on this PR
- [ ] Squash-merge → tag `v0.8.1` → release workflow auto-publishes to npm with provenance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch release 0.8.1 published
  * Disabled default alert flags for environment variables, filesystem access, network access, URL strings, and IP proxy detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->