### PR TITLE
ci(codecov): allow no-upload PRs to pass status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,10 +5,17 @@ coverage:
         target: auto
         threshold: 0.5%
         # Project coverage shouldn't drop more than 0.5% in any single PR.
+        if_no_uploads: success
+        if_not_found: success
+        # PRs that don't touch source code (CI bumps, doc-only, GitHub
+        # Actions updates) produce no coverage upload — pass instead of
+        # blocking on a missing report.
     patch:
       default:
         target: 95%
         threshold: 1.5%
+        if_no_uploads: success
+        if_not_found: success
         # Strict patch gate (95% target, 1.5% threshold) — new code must
         # be ≥93.5% covered. The 1.5% threshold (vs an absolute 95%
         # requirement) exists for two narrow exceptions, not a blanket


### PR DESCRIPTION
## Summary
- Add `if_no_uploads: success` and `if_not_found: success` to both `project` and `patch` codecov gates.

## Why
PRs that don't touch source code (Dependabot Action bumps, doc-only, workflow tweaks) produce **no coverage upload** → `codecov/patch` and `codecov/project` stay pending forever → branch protection blocks merge indefinitely.

Hit while merging Dependabot PR #41 (`actions/setup-node` 6.3 → 6.4).

## Test plan
- [ ] CI passes
- [ ] After merge, re-run checks on PR #41 → codecov/* should pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI coverage validation configuration. Coverage status checks now succeed when uploads are absent or reports unavailable, allowing pipelines to complete successfully even without coverage artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->