### PR TITLE
docs(readme): add MCP Server badge from badge.mcpx.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 [![Node.js Version](https://img.shields.io/node/v/mercury-invoicing-mcp.svg)](https://nodejs.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![MCP](https://img.shields.io/badge/MCP-1.29-blue)](https://modelcontextprotocol.io)
+[![MCP Server](https://badge.mcpx.dev?type=server 'MCP Server')](https://modelcontextprotocol.io)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/klodr/mercury-invoicing-mcp/pulls)
 
 A Model Context Protocol (MCP) server giving AI assistants (Claude, Cursor, Continue, etc.) full programmatic access to your **Mercury** business banking account, including the **Invoicing API** (one-shot + recurring) which is missing from every other Mercury MCP.


### PR DESCRIPTION
## Summary
- Add `MCP Server` badge from badge.mcpx.dev next to the existing `MCP-1.29` SDK badge.

## Why
Visually flag the project as an MCP Server (vs. a client) for discoverability in MCP catalogs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Model Context Protocol Server badge to the project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->