### PR TITLE
docs: move Contributing section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+Issues and PRs welcome. Please open an issue first for substantial changes.
+
+## Before submitting a PR
+
+1. `npm install` then `npm test` (must stay at 82/82 with ≥98% statement coverage)
+2. `npm run build` (must succeed; the published tarball is only `dist/index.js` + `package.json` + `README.md` + `LICENSE`)
+3. Update `CHANGELOG.md` under `[Unreleased]`
+4. If you add or rename a tool, update the `Tools` section in the README and the `defineTool(server, ...)` call in `src/tools/`
+5. New write tools must be registered in `TOOL_CATEGORIES` (`src/middleware.ts`) so they are rate-limited
+
+## Releases (maintainers only)
+
+Do not edit `version` by hand — run `npm version patch|minor|major`. The lifecycle hook calls `scripts/sync-version.mjs` to propagate the bump into `server.json` and `src/server.ts`. Editing `package.json` directly will leave those two files out of sync.

--- a/README.md
+++ b/README.md
@@ -306,14 +306,4 @@ MIT — see [LICENSE](./LICENSE).
 
 ## Contributing
 
-Issues and PRs welcome. Please open an issue first for substantial changes.
-
-Before submitting a PR:
-
-1. `npm install` then `npm test` (must stay at 82/82 with ≥98% statement coverage)
-2. `npm run build` (must succeed; the published tarball is only `dist/index.js` + `package.json` + `README.md` + `LICENSE`)
-3. Update `CHANGELOG.md` under `[Unreleased]`
-4. If you add or rename a tool, update the `Tools` section in this README and the `defineTool(server, ...)` call in `src/tools/`
-5. New write tools must be registered in `TOOL_CATEGORIES` (`src/middleware.ts`) so they are rate-limited
-
-For releases, do not edit `version` by hand — run `npm version patch|minor|major`; the lifecycle hook calls `scripts/sync-version.mjs` to propagate the bump into `server.json` and `src/server.ts`.
+Issues and PRs welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the test/build/coverage checklist and release process.


### PR DESCRIPTION
Moves the Contributing section out of the README into a dedicated CONTRIBUTING.md (keeping READMEs focused on users).

Also promotes the warning about `npm version` vs `sync-version.mjs` into a proper Releases section — editing `package.json`'s `version` by hand would leave `server.json` and `src/server.ts` out of sync.

[skip-readme]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Created comprehensive contribution guidelines covering testing, build requirements, changelog updates, tool registration, and release procedures.
  * Simplified README's contribution section by directing contributors to the new dedicated documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->