### PR TITLE
chore(coderabbit): disable request_changes_workflow

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,7 +6,9 @@ early_access: false
 
 reviews:
   profile: assertive          # stricter feedback (vs "chill")
-  request_changes_workflow: true
+  # request_changes_workflow intentionally not set — we don't want
+  # @coderabbitai approve shortcutting the human-approval requirement
+  # or @coderabbitai resolve blanket-clearing conversation threads.
   high_level_summary: true
   poem: false                 # no decorative poetry
   review_status: true


### PR DESCRIPTION
Removes `request_changes_workflow: true` from the CodeRabbit config.

**Why:** we don't want either of the two shortcuts this flag unlocks:

- `@coderabbitai approve` — lets CodeRabbit post a formal "Approved" review, which could count toward a branch-protection approval requirement. We want human approval, not bot approval.
- `@coderabbitai resolve` — blanket-marks every open CodeRabbit conversation as resolved, which can hide real findings among false positives. Too brutal.

**Alternatives we'll use instead:**
- Reply inline to the specific comment (CodeRabbit re-evaluates on the next push)
- `@coderabbitai ignore <reason>` on a single thread — surgical

[skip-readme]