### PR TITLE
feat: dual-window rate limits (daily + 30d rolling monthly)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (BREAKING for env overrides + state file)
+
+- **Dual-window rate limits**: every write tool now enforces both a daily
+  and a 30-day rolling cap, rejecting calls as soon as either window is
+  at its limit. Previously only a daily cap existed, so a slow agent
+  could spread enough calls across weeks to drain an account while
+  staying under the daily threshold.
+- Per-category limits replaced with finer-grained **per-bucket limits**
+  (see README for the full matrix). Example: `create_customer` /
+  `update_customer` / `delete_customer` now share a `customers_write`
+  bucket capped at 3/day, 60/month (previously pooled under `invoicing`
+  at 100/day with no monthly cap).
+- Rate-limit env override format changed from
+  `MERCURY_MCP_RATE_LIMIT_<category>=N/day` to
+  `MERCURY_MCP_RATE_LIMIT_<bucket>=D/day,M/month` — both windows must
+  be supplied. Old-format values now fall back to the built-in default
+  (with a stderr warning) instead of being silently mis-parsed.
+- Rate-limit state file (`~/.mercury-mcp/ratelimit.json`) is now keyed
+  by bucket name. Pre-existing state keyed by category (`money`,
+  `invoicing`, …) is ignored on first load after upgrade — effectively
+  a fresh 30-day window starts from the upgrade moment.
+- Rate-limit errors now return a structured JSON payload with
+  `error_type` (`daily_limit_exceeded` or `monthly_limit_exceeded`),
+  `message`, `hint`, and `retry_after` (ISO 8601 timestamp) — so the
+  agent can back off at the right granularity instead of guessing.
+
+### Security
+
+- Monthly cap blocks a drain-by-pacing attack that the previous
+  single-window limiter could not catch: e.g. 7 `send_money` calls per
+  day × 30 days = 210 outbound payments that used to pass silently.
+  The new 150/month cap on `payments` stops this at 150.
+
 ## [0.8.1] - 2026-04-19
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@ Issues and PRs welcome. Please open an issue first for substantial changes.
 
 ## Before submitting a PR
 
-1. `npm install` then `npm test` (must stay at 82/82 with ≥98% statement coverage)
+1. `npm install` then `npm test` (must stay green with ≥98% statement coverage)
 2. `npm run build` (must succeed; the published tarball is only `dist/index.js` + `package.json` + `README.md` + `LICENSE`)
 3. Update `CHANGELOG.md` under `[Unreleased]`
 4. If you add or rename a tool, update the `Tools` section in the README and the `defineTool(server, ...)` call in `src/tools/`
-5. New write tools must be registered in `TOOL_CATEGORIES` (`src/middleware.ts`) so they are rate-limited
+5. New write tools must be registered in `TOOL_BUCKET` + `DEFAULT_BUCKET_LIMITS` (`src/middleware.ts`) so they are rate-limited
 
 ## Releases (maintainers only)
 

--- a/README.md
+++ b/README.md
@@ -240,27 +240,44 @@ Restart the gateway (`docker restart openclaw-openclaw-gateway-1` or your equiva
 
 This MCP includes three middleware layers that activate automatically on write tools (read tools are unaffected):
 
-#### 1. Rate limiting
+#### 1. Rate limiting (dual-window)
 
-Per-category daily limits prevent runaway agents from draining accounts or spamming the API.
+Each write tool is mapped to a **bucket**. Every bucket enforces **two rolling windows simultaneously** — a daily cap (24 h) and a monthly cap (30-day rolling). A call is rejected as soon as either window is at its cap, so a runaway agent cannot drain accounts even if it stays under the daily limit by pacing itself over weeks.
 
-| Category | Tools | Default |
-|---|---|---|
-| `money` | send_money, request_send_money | 50/day |
-| `internal_transfer` | create_internal_transfer (between your own Mercury accounts) | 5/day |
-| `invoicing` | create/update/cancel invoice + create/update/delete customer | 100/day |
-| `banking` | add_recipient, update_recipient, update_transaction | 200/day |
-| `webhooks` | create/update/delete webhook | 5/day |
+| Bucket | Tools | Daily | Monthly (30d) |
+|---|---|---|---|
+| `payments` | send_money, request_send_money | 7 | 150 |
+| `internal_transfer` | create_internal_transfer | 2 | 40 |
+| `invoices_write` | create_invoice, update_invoice | 10 | 200 |
+| `invoices_cancel` | cancel_invoice | 3 | 30 |
+| `customers_write` | create_customer, update_customer, delete_customer | 3 | 60 |
+| `recipients_add` | add_recipient | 3 | 45 |
+| `recipients_update` | update_recipient | 2 | 15 |
+| `transactions_update` | update_transaction (bookkeeping, tagging, receipts) | 50 | 500 |
+| `webhooks_create` | create_webhook | 2 | 15 |
+| `webhooks_update` | update_webhook | 2 | 15 |
+| `webhooks_delete` | delete_webhook | 2 | 15 |
 
-Override per category (units: `/hour`, `/day`, `/week`):
+Override per bucket (both windows must be supplied):
 
 ```bash
-MERCURY_MCP_RATE_LIMIT_money=200/day      # bigger supplier batch
-MERCURY_MCP_RATE_LIMIT_invoicing=1000/day # large monthly billing run
-MERCURY_MCP_RATE_LIMIT_DISABLE=true       # disable all rate limiting (not recommended)
+MERCURY_MCP_RATE_LIMIT_payments=15/day,300/month   # larger supplier batch
+MERCURY_MCP_RATE_LIMIT_invoices_write=20/day,400/month  # large monthly billing run
+MERCURY_MCP_RATE_LIMIT_DISABLE=true                # disable all rate limiting (not recommended)
 ```
 
-When exceeded, the tool returns an `isError: true` response with a clear message and retry hint — the agent learns to back off naturally.
+When exceeded, the tool returns an `isError: true` response with a structured JSON payload:
+
+```json
+{
+  "error_type": "daily_limit_exceeded",
+  "message": "Daily Limit Exceeded",
+  "hint": "Daily Limit Exceeded: mercury_send_money (bucket: payments) capped at 7 per 24h. Retry in ~180 min. Override with MERCURY_MCP_RATE_LIMIT_payments=D/day,M/month if this is a legitimate batch.",
+  "retry_after": "2026-04-22T00:00:00.000Z"
+}
+```
+
+`error_type` is either `daily_limit_exceeded` or `monthly_limit_exceeded` — the agent learns to back off at the right granularity.
 
 The rate-limit window **survives process restarts**. State is persisted to `~/.mercury-mcp/ratelimit.json` (mode `0o600`); override the location with `MERCURY_MCP_STATE_DIR=/abs/path` if you need to share state between hosts or pin it to a specific volume. Without persistence, an MCP host that respawns the server per session would silently bypass the limit.
 

--- a/README.md
+++ b/README.md
@@ -266,18 +266,19 @@ MERCURY_MCP_RATE_LIMIT_invoices_write=20/day,400/month  # large monthly billing 
 MERCURY_MCP_RATE_LIMIT_DISABLE=true                # disable all rate limiting (not recommended)
 ```
 
-When exceeded, the tool returns an `isError: true` response with a structured JSON payload:
+When exceeded, the tool returns an `isError: true` response with a structured JSON payload. The `source` and `error_type` prefix make it unambiguous that this is a **local MCP safeguard** — the call was never sent to Mercury. A genuine Mercury 429 surfaces separately as `"Mercury API error 429: ..."`.
 
 ```json
 {
-  "error_type": "daily_limit_exceeded",
-  "message": "Daily Limit Exceeded",
+  "source": "mcp_safeguard",
+  "error_type": "mcp_rate_limit_daily_exceeded",
+  "message": "MCP Rate Limit Exceeded — Daily (local safeguard, not a Mercury API error)",
   "hint": "Daily Limit Exceeded: mercury_send_money (bucket: payments) capped at 7 per 24h. Retry in ~180 min. Override with MERCURY_MCP_RATE_LIMIT_payments=D/day,M/month if this is a legitimate batch.",
   "retry_after": "2026-04-22T00:00:00.000Z"
 }
 ```
 
-`error_type` is either `daily_limit_exceeded` or `monthly_limit_exceeded` — the agent learns to back off at the right granularity.
+`error_type` is either `mcp_rate_limit_daily_exceeded` or `mcp_rate_limit_monthly_exceeded` — the agent learns to back off at the right granularity without confusing the MCP's local cap with a server-side Mercury limit.
 
 The rate-limit window **survives process restarts**. State is persisted to `~/.mercury-mcp/ratelimit.json` (mode `0o600`); override the location with `MERCURY_MCP_STATE_DIR=/abs/path` if you need to share state between hosts or pin it to a specific volume. Without persistence, an MCP host that respawns the server per session would silently bypass the limit.
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,21 @@
 /**
- * MCP middleware: dry-run, rate limiting, audit log.
+ * MCP middleware: dry-run, dual-window rate limiting, audit log.
+ *
+ * Each write tool is associated with a bucket. Buckets enforce two
+ * rolling windows simultaneously:
+ *   - daily  (24h)
+ *   - monthly (30-day rolling)
+ * A call is rejected as soon as either window is at its cap. The daily
+ * window is checked first so an explicit "Daily Limit Exceeded" is
+ * surfaced when both caps are hit at once.
+ *
+ * Persistence: ~/.mercury-mcp/ratelimit.json (mode 0o600, atomic write).
+ * State is keyed by bucket; entries are arrays of Unix-ms timestamps
+ * pruned to the monthly window on every access.
+ *
+ * Env overrides:
+ *   MERCURY_MCP_RATE_LIMIT_<BUCKET>=D/day,M/month
+ *   MERCURY_MCP_RATE_LIMIT_DISABLE=true    # disable all limits
  */
 
 import { appendFileSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
@@ -8,63 +24,87 @@ import { homedir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
 import { MercuryError } from "./client.js";
 
-const TOOL_CATEGORIES: Record<string, string> = {
-  // Money movements
-  mercury_send_money: "money",
-  mercury_request_send_money: "money",
+const DAY_MS = 86_400_000;
+const MONTH_MS = 30 * DAY_MS; // 30-day rolling window
+
+/**
+ * Tool → bucket. Tools that share a bucket also share the same
+ * history array (e.g. `send_money` and `request_send_money` both
+ * count against the `payments` bucket).
+ */
+const TOOL_BUCKET: Record<string, string> = {
+  // Money out
+  mercury_send_money: "payments",
+  mercury_request_send_money: "payments",
   mercury_create_internal_transfer: "internal_transfer",
-  // AR (invoicing + customers)
-  mercury_create_invoice: "invoicing",
-  mercury_update_invoice: "invoicing",
-  mercury_cancel_invoice: "invoicing",
-  mercury_create_customer: "invoicing",
-  mercury_update_customer: "invoicing",
-  mercury_delete_customer: "invoicing",
+
+  // Invoicing
+  mercury_create_invoice: "invoices_write",
+  mercury_update_invoice: "invoices_write",
+  mercury_cancel_invoice: "invoices_cancel",
+
+  // Customers (AR)
+  mercury_create_customer: "customers_write",
+  mercury_update_customer: "customers_write",
+  mercury_delete_customer: "customers_write",
+
   // Banking writes
-  mercury_add_recipient: "banking",
-  mercury_update_recipient: "banking",
-  mercury_update_transaction: "banking",
-  // Webhooks (config)
-  mercury_create_webhook: "webhooks",
-  mercury_update_webhook: "webhooks",
-  mercury_delete_webhook: "webhooks",
+  mercury_add_recipient: "recipients_add",
+  mercury_update_recipient: "recipients_update",
+  mercury_update_transaction: "transactions_update",
+
+  // Webhooks
+  mercury_create_webhook: "webhooks_create",
+  mercury_update_webhook: "webhooks_update",
+  mercury_delete_webhook: "webhooks_delete",
 };
 
-const DEFAULT_LIMITS_PER_DAY: Record<string, number> = {
-  money: 50,
-  internal_transfer: 5,
-  invoicing: 100,
-  banking: 200,
-  webhooks: 5,
+interface BucketLimit {
+  daily: number;
+  monthly: number;
+}
+
+const DEFAULT_BUCKET_LIMITS: Record<string, BucketLimit> = {
+  payments: { daily: 7, monthly: 150 },
+  internal_transfer: { daily: 2, monthly: 40 },
+  invoices_write: { daily: 10, monthly: 200 },
+  invoices_cancel: { daily: 3, monthly: 30 },
+  customers_write: { daily: 3, monthly: 60 },
+  recipients_add: { daily: 3, monthly: 45 },
+  recipients_update: { daily: 2, monthly: 15 },
+  transactions_update: { daily: 50, monthly: 500 },
+  webhooks_create: { daily: 2, monthly: 15 },
+  webhooks_update: { daily: 2, monthly: 15 },
+  webhooks_delete: { daily: 2, monthly: 15 },
 };
 
-interface ParsedRate {
-  count: number;
-  windowMs: number;
+/**
+ * Parse an override env var of the form "D/day,M/month".
+ * Returns null on malformed input so the caller can fall back.
+ */
+function parseOverride(raw: string): BucketLimit | null {
+  const parts = raw.split(",").map((s) => s.trim());
+  if (parts.length !== 2) return null;
+  const dailyM = parts[0].match(/^(\d+)\s*\/\s*day$/i);
+  const monthlyM = parts[1].match(/^(\d+)\s*\/\s*month$/i);
+  if (!dailyM || !monthlyM) return null;
+  const daily = Number(dailyM[1]);
+  const monthly = Number(monthlyM[1]);
+  if (daily < 1 || monthly < 1) return null;
+  return { daily, monthly };
 }
 
-function parseRate(raw: string): ParsedRate | null {
-  const m = raw.match(/^(\d+)\s*\/\s*(hour|day|week)$/i);
-  if (!m) return null;
-  const count = Number(m[1]);
-  const unit = m[2].toLowerCase();
-  const windowMs = unit === "hour" ? 3600_000 : unit === "day" ? 86400_000 : 604800_000;
-  return { count, windowMs };
-}
-
-function getRateLimit(category: string): ParsedRate | null {
-  const envKey = `MERCURY_MCP_RATE_LIMIT_${category}`;
+function getBucketLimit(bucket: string): BucketLimit | null {
+  const envKey = `MERCURY_MCP_RATE_LIMIT_${bucket}`;
   const raw = process.env[envKey];
   if (raw) {
-    const parsed = parseRate(raw);
+    const parsed = parseOverride(raw);
     if (parsed) return parsed;
     console.error(
-      `Invalid rate limit format for ${envKey}: "${raw}" — expected like "100/day". Using default.`,
+      `Invalid rate limit format for ${envKey}: "${raw}" — expected like "7/day,150/month". Using default.`,
     );
   }
-  const defaultCount = DEFAULT_LIMITS_PER_DAY[category];
-  if (defaultCount === undefined) return null;
-  return { count: defaultCount, windowMs: 86400_000 };
+  return DEFAULT_BUCKET_LIMITS[bucket] ?? null;
 }
 
 const callHistory = new Map<string, number[]>();
@@ -146,54 +186,68 @@ export function resetRateLimitHistory(): void {
   stateLoaded = false;
 }
 
+export type LimitType = "daily" | "monthly";
+
 export class RateLimitError extends Error {
   constructor(
     public toolName: string,
-    public category: string,
+    public bucket: string,
+    public limitType: LimitType,
     public limit: number,
-    public windowMs: number,
     public retryAfterMs: number,
   ) {
-    const win =
-      windowMs === 86400_000
-        ? "day"
-        : windowMs === 3600_000
-          ? "hour"
-          : `${Math.round(windowMs / 1000)}s`;
-    const retrySec = Math.ceil(retryAfterMs / 1000);
+    const retryMinutes = Math.ceil(retryAfterMs / 60_000);
+    const windowLabel = limitType === "daily" ? "24h" : "30-day rolling";
+    const title = limitType === "daily" ? "Daily Limit Exceeded" : "Monthly Limit Exceeded";
     super(
-      `Rate limit exceeded for ${toolName} (category: ${category}, limit: ${limit}/${win}). Retry in ${retrySec}s. ` +
-        `Override with MERCURY_MCP_RATE_LIMIT_${category}=N/day if this is a legitimate batch.`,
+      `${title}: ${toolName} (bucket: ${bucket}) capped at ${limit} per ${windowLabel}. ` +
+        `Retry in ~${retryMinutes} min. ` +
+        `Override with MERCURY_MCP_RATE_LIMIT_${bucket}=D/day,M/month if this is a legitimate batch.`,
     );
     this.name = "RateLimitError";
   }
 }
 
 /**
- * Returns true if the call is allowed; throws RateLimitError otherwise.
- * Mutates internal call history if allowed.
+ * Enforce both rate-limit windows for a tool call.
+ *
+ * - No-op for read tools or tools not in TOOL_BUCKET
+ * - Prunes records older than the monthly window before counting
+ * - Daily window checked first (so an explicit "Daily Limit Exceeded"
+ *   is surfaced when both caps happen to land at the same instant)
+ * - On allow: appends a timestamp and persists state
+ * - On deny: throws RateLimitError with the limit type that failed
  */
 export function enforceRateLimit(toolName: string): void {
   if (process.env.MERCURY_MCP_RATE_LIMIT_DISABLE === "true") return;
 
-  const category = TOOL_CATEGORIES[toolName];
-  if (!category) return; // read tools or untracked → no limit
+  const bucket = TOOL_BUCKET[toolName];
+  if (!bucket) return; // read tool or untracked → no limit
 
-  const rl = getRateLimit(category);
-  if (!rl) return;
+  const limits = getBucketLimit(bucket);
+  if (!limits) return;
 
   loadCallHistory();
 
   const now = Date.now();
-  const records = (callHistory.get(category) ?? []).filter((ts) => now - ts < rl.windowMs);
+  // Prune: keep only records within the monthly window
+  const records = (callHistory.get(bucket) ?? []).filter((ts) => now - ts < MONTH_MS);
 
-  if (records.length >= rl.count) {
-    const retryAfterMs = rl.windowMs - (now - records[0]);
-    throw new RateLimitError(toolName, category, rl.count, rl.windowMs, retryAfterMs);
+  // Daily window: records within the last 24h
+  const dailyRecords = records.filter((ts) => now - ts < DAY_MS);
+  if (dailyRecords.length >= limits.daily) {
+    const retryAfterMs = DAY_MS - (now - dailyRecords[0]);
+    throw new RateLimitError(toolName, bucket, "daily", limits.daily, retryAfterMs);
+  }
+
+  // Monthly window: records is already pruned to 30 days
+  if (records.length >= limits.monthly) {
+    const retryAfterMs = MONTH_MS - (now - records[0]);
+    throw new RateLimitError(toolName, bucket, "monthly", limits.monthly, retryAfterMs);
   }
 
   records.push(now);
-  callHistory.set(category, records);
+  callHistory.set(bucket, records);
   persistCallHistory();
 }
 
@@ -260,8 +314,27 @@ export function logAudit(
 export type ToolResult = { content: { type: "text"; text: string }[]; isError?: boolean };
 
 /**
+ * Format a RateLimitError as a structured JSON payload for the MCP client.
+ * The LLM gets explicit error_type / message / hint / retry_after fields
+ * instead of a free-form error string.
+ */
+function formatRateLimitError(err: RateLimitError): string {
+  const retryAfter = new Date(Date.now() + err.retryAfterMs).toISOString();
+  return JSON.stringify(
+    {
+      error_type: `${err.limitType}_limit_exceeded`,
+      message: err.limitType === "daily" ? "Daily Limit Exceeded" : "Monthly Limit Exceeded",
+      hint: err.message,
+      retry_after: retryAfter,
+    },
+    null,
+    2,
+  );
+}
+
+/**
  * Wrap a tool handler with rate limit, dry-run, and audit middleware.
- * - Rate limit: throws RateLimitError if exceeded
+ * - Rate limit: returns structured isError payload if either window exceeded
  * - Dry-run: returns a mock response without calling Mercury
  * - Audit log: writes structured entry to MERCURY_MCP_AUDIT_LOG if set
  */
@@ -269,7 +342,7 @@ export function wrapToolHandler<TArgs>(
   toolName: string,
   handler: (args: TArgs) => Promise<ToolResult>,
 ): (args: TArgs) => Promise<ToolResult> {
-  const isWriteOp = toolName in TOOL_CATEGORIES;
+  const isWriteOp = toolName in TOOL_BUCKET;
 
   return async (args: TArgs): Promise<ToolResult> => {
     if (isWriteOp) {
@@ -279,7 +352,7 @@ export function wrapToolHandler<TArgs>(
         if (err instanceof RateLimitError) {
           logAudit(toolName, args, "error");
           return {
-            content: [{ type: "text", text: `Error: ${err.message}` }],
+            content: [{ type: "text", text: formatRateLimitError(err) }],
             isError: true,
           };
         }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -315,15 +315,21 @@ export type ToolResult = { content: { type: "text"; text: string }[]; isError?: 
 
 /**
  * Format a RateLimitError as a structured JSON payload for the MCP client.
- * The LLM gets explicit error_type / message / hint / retry_after fields
- * instead of a free-form error string.
+ *
+ * The `source: "mcp_safeguard"` + `mcp_rate_limit_…` prefix make it
+ * unambiguous that this is a *local* cap enforced by the MCP itself —
+ * the call was never sent to Mercury. A real Mercury 429 comes back
+ * formatted as "Mercury API error 429: …" via the MercuryError branch
+ * in wrapToolHandler; the two are distinct.
  */
 function formatRateLimitError(err: RateLimitError): string {
   const retryAfter = new Date(Date.now() + err.retryAfterMs).toISOString();
+  const windowLabel = err.limitType === "daily" ? "Daily" : "Monthly";
   return JSON.stringify(
     {
-      error_type: `${err.limitType}_limit_exceeded`,
-      message: err.limitType === "daily" ? "Daily Limit Exceeded" : "Monthly Limit Exceeded",
+      source: "mcp_safeguard",
+      error_type: `mcp_rate_limit_${err.limitType}_exceeded`,
+      message: `MCP Rate Limit Exceeded — ${windowLabel} (local safeguard, not a Mercury API error)`,
       hint: err.message,
       retry_after: retryAfter,
     },

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -29,10 +29,22 @@ describe("Middleware", () => {
   beforeEach(() => {
     delete process.env.MERCURY_MCP_DRY_RUN;
     delete process.env.MERCURY_MCP_RATE_LIMIT_DISABLE;
-    delete process.env.MERCURY_MCP_RATE_LIMIT_webhooks;
-    delete process.env.MERCURY_MCP_RATE_LIMIT_money;
-    delete process.env.MERCURY_MCP_RATE_LIMIT_invoicing;
-    delete process.env.MERCURY_MCP_RATE_LIMIT_banking;
+    // Clear every bucket env var a test might set.
+    for (const bucket of [
+      "payments",
+      "internal_transfer",
+      "invoices_write",
+      "invoices_cancel",
+      "customers_write",
+      "recipients_add",
+      "recipients_update",
+      "transactions_update",
+      "webhooks_create",
+      "webhooks_update",
+      "webhooks_delete",
+    ]) {
+      delete process.env[`MERCURY_MCP_RATE_LIMIT_${bucket}`];
+    }
     stateDir = mkdtempSync(join(tmpdir(), "mercury-state-"));
     process.env.MERCURY_MCP_STATE_DIR = stateDir;
     resetRateLimitHistory();
@@ -44,55 +56,100 @@ describe("Middleware", () => {
   });
 
   describe("enforceRateLimit", () => {
-    it("does nothing for read tools (no category)", () => {
+    it("does nothing for read tools (no bucket)", () => {
       expect(() => enforceRateLimit("mercury_list_accounts")).not.toThrow();
-      // Many calls → still no throw
       for (let i = 0; i < 100; i++) enforceRateLimit("mercury_list_accounts");
     });
 
     it("respects MERCURY_MCP_RATE_LIMIT_DISABLE=true", () => {
       process.env.MERCURY_MCP_RATE_LIMIT_DISABLE = "true";
-      // Webhook default is 5/day, but disabled → unlimited
+      // webhooks_create default is 2/day, but disabled → unlimited
       for (let i = 0; i < 10; i++) {
         expect(() => enforceRateLimit("mercury_create_webhook")).not.toThrow();
       }
     });
 
-    it("enforces custom env limit", () => {
-      process.env.MERCURY_MCP_RATE_LIMIT_money = "2/day";
+    it("enforces default daily cap on create_customer (3/day)", () => {
+      enforceRateLimit("mercury_create_customer");
+      enforceRateLimit("mercury_create_customer");
+      enforceRateLimit("mercury_create_customer");
+      expect(() => enforceRateLimit("mercury_create_customer")).toThrow(RateLimitError);
+    });
+
+    it("enforces a dual-window env override", () => {
+      process.env.MERCURY_MCP_RATE_LIMIT_payments = "2/day,5/month";
       enforceRateLimit("mercury_send_money");
       enforceRateLimit("mercury_send_money");
       expect(() => enforceRateLimit("mercury_send_money")).toThrow(RateLimitError);
     });
 
-    it("RateLimitError contains useful info", () => {
-      process.env.MERCURY_MCP_RATE_LIMIT_money = "1/day";
-      enforceRateLimit("mercury_request_send_money"); // 1st OK
+    it("shared bucket: send_money and request_send_money count together", () => {
+      process.env.MERCURY_MCP_RATE_LIMIT_payments = "2/day,5/month";
+      enforceRateLimit("mercury_send_money");
+      enforceRateLimit("mercury_request_send_money");
+      // Third call from either tool trips the shared bucket.
+      expect(() => enforceRateLimit("mercury_send_money")).toThrow(RateLimitError);
+    });
+
+    it("RateLimitError contains limitType=daily and bucket info", () => {
+      process.env.MERCURY_MCP_RATE_LIMIT_payments = "1/day,5/month";
+      enforceRateLimit("mercury_send_money"); // 1st OK
       try {
-        enforceRateLimit("mercury_request_send_money"); // 2nd throws
+        enforceRateLimit("mercury_send_money"); // 2nd trips daily
         fail("Expected RateLimitError");
       } catch (err) {
         expect(err).toBeInstanceOf(RateLimitError);
         const e = err as RateLimitError;
-        expect(e.toolName).toBe("mercury_request_send_money");
-        expect(e.category).toBe("money");
+        expect(e.toolName).toBe("mercury_send_money");
+        expect(e.bucket).toBe("payments");
+        expect(e.limitType).toBe("daily");
         expect(e.limit).toBe(1);
-        expect(e.message).toContain("Rate limit exceeded");
-        expect(e.message).toContain("Override with MERCURY_MCP_RATE_LIMIT_money");
+        expect(e.message).toContain("Daily Limit Exceeded");
+        expect(e.message).toContain("Override with MERCURY_MCP_RATE_LIMIT_payments");
+      }
+    });
+
+    it("monthly window: trips even when daily cap is never reached", () => {
+      process.env.MERCURY_MCP_RATE_LIMIT_payments = "10/day,2/month";
+      enforceRateLimit("mercury_send_money");
+      enforceRateLimit("mercury_send_money");
+      try {
+        enforceRateLimit("mercury_send_money");
+        fail("Expected RateLimitError");
+      } catch (err) {
+        expect(err).toBeInstanceOf(RateLimitError);
+        const e = err as RateLimitError;
+        expect(e.limitType).toBe("monthly");
+        expect(e.message).toContain("Monthly Limit Exceeded");
+        expect(e.message).toContain("30-day rolling");
       }
     });
 
     it("invalid rate limit format logs a warning and falls back to default", () => {
       const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      process.env.MERCURY_MCP_RATE_LIMIT_invoicing = "not-a-rate";
+      process.env.MERCURY_MCP_RATE_LIMIT_invoices_write = "not-a-rate";
       expect(() => enforceRateLimit("mercury_create_invoice")).not.toThrow();
       expect(errSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Invalid rate limit format for MERCURY_MCP_RATE_LIMIT_invoicing"),
+        expect.stringContaining(
+          "Invalid rate limit format for MERCURY_MCP_RATE_LIMIT_invoices_write",
+        ),
       );
     });
 
+    it.each([
+      ["5/day", "single window"],
+      ["5/day,10/week", "unknown monthly unit"],
+      ["0/day,10/month", "zero daily"],
+      ["5/day,0/month", "zero monthly"],
+    ])("rejects override '%s' (%s)", (raw) => {
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      process.env.MERCURY_MCP_RATE_LIMIT_payments = raw;
+      // Falls back to default (7/day, 150/month) — single call stays under.
+      expect(() => enforceRateLimit("mercury_send_money")).not.toThrow();
+    });
+
     it("persists call history across simulated process restarts", () => {
-      process.env.MERCURY_MCP_RATE_LIMIT_money = "2/day";
+      process.env.MERCURY_MCP_RATE_LIMIT_payments = "2/day,10/month";
       enforceRateLimit("mercury_send_money");
 
       // Open the persisted state once and use fstat + read on the same fd
@@ -103,7 +160,7 @@ describe("Middleware", () => {
         const stat = fstatSync(fd);
         expect(stat.mode & 0o777).toBe(0o600);
         const persisted = JSON.parse(readFileSync(fd, "utf8")) as Record<string, number[]>;
-        expect(persisted.money).toHaveLength(1);
+        expect(persisted.payments).toHaveLength(1);
       } finally {
         closeSync(fd);
       }
@@ -116,7 +173,7 @@ describe("Middleware", () => {
 
     it("starts fresh when state file is corrupted", () => {
       const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      process.env.MERCURY_MCP_RATE_LIMIT_money = "1/day";
+      process.env.MERCURY_MCP_RATE_LIMIT_payments = "1/day,5/month";
       mkdirSync(stateDir, { recursive: true });
       writeFileSync(join(stateDir, "ratelimit.json"), "{not valid json");
       expect(() => enforceRateLimit("mercury_send_money")).not.toThrow();
@@ -124,44 +181,26 @@ describe("Middleware", () => {
     });
 
     it("ignores state files whose JSON shape is unexpected (array root)", () => {
-      process.env.MERCURY_MCP_RATE_LIMIT_money = "1/day";
+      process.env.MERCURY_MCP_RATE_LIMIT_payments = "1/day,5/month";
       mkdirSync(stateDir, { recursive: true });
-      // JSON.parse succeeds but the type-guard on parsed-is-object rejects.
       writeFileSync(join(stateDir, "ratelimit.json"), "[1,2,3]");
       expect(() => enforceRateLimit("mercury_send_money")).not.toThrow();
     });
 
     it("skips entries whose value is not a number array", () => {
-      process.env.MERCURY_MCP_RATE_LIMIT_money = "1/day";
+      process.env.MERCURY_MCP_RATE_LIMIT_payments = "1/day,5/month";
       mkdirSync(stateDir, { recursive: true });
-      // money entry is a number-array (loaded — needs a timestamp inside the
-      // 1-day window so it actually counts), webhooks is a string (skipped
-      // by the type-guard at middleware.ts:105).
       writeFileSync(
         join(stateDir, "ratelimit.json"),
-        `{"money":[${Date.now()}],"webhooks":"not-an-array"}`,
+        `{"payments":[${Date.now()}],"webhooks_create":"not-an-array"}`,
       );
-      // money already has 1 prior call → 2nd should hit the limit.
+      // payments already has 1 prior call → 2nd should hit the daily cap.
       expect(() => enforceRateLimit("mercury_send_money")).toThrow(RateLimitError);
-    });
-
-    it("supports the 'week' window in custom rate limits", () => {
-      process.env.MERCURY_MCP_RATE_LIMIT_money = "1/week";
-      enforceRateLimit("mercury_send_money");
-      try {
-        enforceRateLimit("mercury_send_money");
-        fail("Expected RateLimitError");
-      } catch (err) {
-        expect(err).toBeInstanceOf(RateLimitError);
-        // The week window doesn't have a short label — falls through to seconds.
-        expect((err as RateLimitError).message).toMatch(/limit: 1\/\d+s\)/);
-      }
     });
 
     it("logs (and does not throw) when the state file cannot be read", () => {
       const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      process.env.MERCURY_MCP_RATE_LIMIT_money = "1/day";
-      // Existing state file with mode 0 → readFileSync raises EACCES (not ENOENT).
+      process.env.MERCURY_MCP_RATE_LIMIT_payments = "1/day,5/month";
       mkdirSync(stateDir, { recursive: true });
       const stateFile = join(stateDir, "ratelimit.json");
       writeFileSync(stateFile, "{}");
@@ -176,11 +215,10 @@ describe("Middleware", () => {
 
     it("does NOT clobber an unreadable state file when persisting", () => {
       vi.spyOn(console, "error").mockImplementation(() => {});
-      process.env.MERCURY_MCP_RATE_LIMIT_money = "1/day";
-      // Pre-existing state file with prior counter, made unreadable mid-session.
+      process.env.MERCURY_MCP_RATE_LIMIT_payments = "1/day,5/month";
       mkdirSync(stateDir, { recursive: true });
       const stateFile = join(stateDir, "ratelimit.json");
-      const originalContent = '{"money":[1,2,3]}';
+      const originalContent = '{"payments":[1,2,3]}';
       writeFileSync(stateFile, originalContent);
       chmodSync(stateFile, 0o000);
       try {
@@ -188,14 +226,12 @@ describe("Middleware", () => {
       } finally {
         chmodSync(stateFile, 0o600);
       }
-      // The file must still hold the original counter — fail-closed on persist.
       expect(readFileSync(stateFile, "utf8")).toBe(originalContent);
     });
 
     it("logs (and does not throw) when the state file cannot be persisted", () => {
       const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      process.env.MERCURY_MCP_RATE_LIMIT_money = "1/day";
-      // Pre-create the state dir read-only so writeFileSync(tmp) raises EACCES.
+      process.env.MERCURY_MCP_RATE_LIMIT_payments = "1/day,5/month";
       mkdirSync(stateDir, { recursive: true });
       chmodSync(stateDir, 0o500);
       try {
@@ -241,8 +277,8 @@ describe("Middleware", () => {
       expect(result.content[0].text).toContain("mercury_create_invoice");
     });
 
-    it("returns isError when rate limit is exceeded", async () => {
-      process.env.MERCURY_MCP_RATE_LIMIT_webhooks = "1/day";
+    it("returns structured daily-limit isError payload when rate limit is exceeded", async () => {
+      process.env.MERCURY_MCP_RATE_LIMIT_webhooks_create = "1/day,5/month";
       const handler = vi.fn(async () => ({
         content: [{ type: "text" as const, text: "ok" }],
       }));
@@ -250,7 +286,26 @@ describe("Middleware", () => {
       await wrapped({});
       const result2 = await wrapped({});
       expect(result2.isError).toBe(true);
-      expect(result2.content[0].text).toContain("Rate limit exceeded");
+      const payload = JSON.parse(result2.content[0].text) as Record<string, string>;
+      expect(payload.error_type).toBe("daily_limit_exceeded");
+      expect(payload.message).toBe("Daily Limit Exceeded");
+      expect(payload.hint).toContain("mercury_create_webhook");
+      expect(payload.retry_after).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it("returns structured monthly-limit isError payload when only monthly cap is hit", async () => {
+      process.env.MERCURY_MCP_RATE_LIMIT_webhooks_create = "10/day,2/month";
+      const handler = vi.fn(async () => ({
+        content: [{ type: "text" as const, text: "ok" }],
+      }));
+      const wrapped = wrapToolHandler("mercury_create_webhook", handler);
+      await wrapped({});
+      await wrapped({});
+      const result3 = await wrapped({});
+      expect(result3.isError).toBe(true);
+      const payload = JSON.parse(result3.content[0].text) as Record<string, string>;
+      expect(payload.error_type).toBe("monthly_limit_exceeded");
+      expect(payload.message).toBe("Monthly Limit Exceeded");
     });
 
     it("converts MercuryError 403 on AR tool to isError with Plus-plan hint", async () => {
@@ -377,7 +432,6 @@ describe("Middleware", () => {
 
     it("does nothing when MERCURY_MCP_AUDIT_LOG is unset", () => {
       logAudit("mercury_send_money", { amount: 100 }, "ok");
-      // No-op (no file path), no throw
     });
 
     it("writes redacted entry to absolute path with mode 0600", () => {
@@ -399,7 +453,6 @@ describe("Middleware", () => {
 
     it("does not throw when write fails (best-effort)", () => {
       const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      // Path inside a non-existent dir → ENOENT
       process.env.MERCURY_MCP_AUDIT_LOG = "/nonexistent-dir-mercury-test/audit.log";
       expect(() => logAudit("mercury_send_money", {}, "error")).not.toThrow();
       expect(errSpy).toHaveBeenCalledWith(

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -287,8 +287,11 @@ describe("Middleware", () => {
       const result2 = await wrapped({});
       expect(result2.isError).toBe(true);
       const payload = JSON.parse(result2.content[0].text) as Record<string, string>;
-      expect(payload.error_type).toBe("daily_limit_exceeded");
-      expect(payload.message).toBe("Daily Limit Exceeded");
+      expect(payload.source).toBe("mcp_safeguard");
+      expect(payload.error_type).toBe("mcp_rate_limit_daily_exceeded");
+      expect(payload.message).toBe(
+        "MCP Rate Limit Exceeded — Daily (local safeguard, not a Mercury API error)",
+      );
       expect(payload.hint).toContain("mercury_create_webhook");
       expect(payload.retry_after).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     });
@@ -304,8 +307,11 @@ describe("Middleware", () => {
       const result3 = await wrapped({});
       expect(result3.isError).toBe(true);
       const payload = JSON.parse(result3.content[0].text) as Record<string, string>;
-      expect(payload.error_type).toBe("monthly_limit_exceeded");
-      expect(payload.message).toBe("Monthly Limit Exceeded");
+      expect(payload.source).toBe("mcp_safeguard");
+      expect(payload.error_type).toBe("mcp_rate_limit_monthly_exceeded");
+      expect(payload.message).toBe(
+        "MCP Rate Limit Exceeded — Monthly (local safeguard, not a Mercury API error)",
+      );
     });
 
     it("converts MercuryError 403 on AR tool to isError with Plus-plan hint", async () => {


### PR DESCRIPTION
## Summary

Replaces the single-window (daily-only) rate limiter with a **dual-window** design: every write tool is now tied to a bucket that enforces **both a 24 h cap and a 30-day rolling cap simultaneously**. A call is rejected as soon as either window is at its limit.

### Why

The previous limiter let a slow agent spread calls across weeks and still drain an account while staying under the daily cap. Concretely: 7 `send_money` calls per day over 30 days = **210 outbound payments** that used to pass silently. The new monthly cap on `payments` stops that at 150.

### New limits matrix

| Bucket | Tools | Daily | Monthly (30d) |
|---|---|---|---|
| `payments` | send_money, request_send_money | 7 | 150 |
| `internal_transfer` | create_internal_transfer | 2 | 40 |
| `invoices_write` | create_invoice, update_invoice | 10 | 200 |
| `invoices_cancel` | cancel_invoice | 3 | 30 |
| `customers_write` | create/update/delete_customer | 3 | 60 |
| `recipients_add` | add_recipient | 3 | 45 |
| `recipients_update` | update_recipient | 2 | 15 |
| `transactions_update` | update_transaction | 50 | 500 |
| `webhooks_create/update/delete` (each) | corresponding webhook op | 2 | 15 |

### Structured error payload

```json
{
  "error_type": "daily_limit_exceeded" | "monthly_limit_exceeded",
  "message": "Daily Limit Exceeded" | "Monthly Limit Exceeded",
  "hint": "<detailed reason + override suggestion>",
  "retry_after": "2026-04-22T00:00:00.000Z"
}
```

Lets the agent back off at the right granularity instead of a generic "try again".

## Breaking changes (for env overrides + state file)

- Env format: `MERCURY_MCP_RATE_LIMIT_<BUCKET>=D/day,M/month` — both windows required; old `N/day` form falls back to defaults with a stderr warning.
- State file keys: now bucket names (`payments`, `customers_write`, …). Pre-upgrade category keys (`money`, `invoicing`, …) are ignored on first load — effectively a fresh 30-day window starts from the upgrade moment.

## Test plan

- [x] `npm test` — 107/107 passing (added shared-bucket + dual-window + structured-payload tests)
- [x] Coverage — 100 % lines/functions, 99.3 % statements (>98 % target)
- [x] `npm run build` / `npm run lint` / prettier clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rate limiting enforces dual windows: 24-hour daily cap and 30-day rolling monthly cap per write tool bucket.
  * Structured JSON error responses now include error type, message, hint, and ISO 8601 retry timestamp.

* **Documentation**
  * Updated rate-limiting safeguard documentation with new configuration format and error response specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->