### PR TITLE
docs(security): describe dual-window rate limits

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,10 +33,13 @@ maintainer commits to, and limits that callers must account for.
   that a single-day limit would miss. Each limit is configurable via
   `MERCURY_MCP_RATE_LIMIT_<BUCKET>=D/day,M/month`. A dry-run mode
   (`MERCURY_MCP_DRY_RUN=true`) lets you exercise prompts without hitting
-  Mercury. When either window is exceeded the MCP returns a structured
-  `isError: true` payload with `source: "mcp_safeguard"` and
+  Mercury. When either window is exceeded, `wrapToolHandler` returns a
+  `ToolResult` with `isError: true` set as a sibling of the `content`
+  array (per the MCP spec); the first entry of `content` is a text block
+  whose body is a JSON document with `source: "mcp_safeguard"` and
   `error_type: "mcp_rate_limit_{daily,monthly}_exceeded"` — unambiguously
-  distinct from a server-side Mercury 429.
+  distinct from a server-side Mercury 429, which surfaces as
+  `"Mercury API error 429: …"` via the `MercuryError` branch.
 - **Optional audit trail**: `MERCURY_MCP_AUDIT_LOG=/abs/path/audit.log` writes
   an append-only JSON Lines record (file mode `0o600`, sensitive fields
   redacted) of every write call.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,9 +27,16 @@ maintainer commits to, and limits that callers must account for.
 - **Least-privilege CI**: the release workflow is split into a read-only build
   job and a release-only publish job that holds `NPM_TOKEN`.
 - **Defense against runaway agents**: rate-limiting middleware caps write
-  operations per category (configurable via `MERCURY_MCP_RATE_LIMIT_*`), and a
-  dry-run mode (`MERCURY_MCP_DRY_RUN=true`) lets you exercise prompts without
-  hitting Mercury.
+  operations per bucket (e.g. `payments`, `customers_write`, `invoices_write`)
+  with a **dual-window policy**: each call must satisfy both a daily (24h)
+  and a monthly (30-day rolling) cap, blocking a slow drain-by-pacing attack
+  that a single-day limit would miss. Each limit is configurable via
+  `MERCURY_MCP_RATE_LIMIT_<BUCKET>=D/day,M/month`. A dry-run mode
+  (`MERCURY_MCP_DRY_RUN=true`) lets you exercise prompts without hitting
+  Mercury. When either window is exceeded the MCP returns a structured
+  `isError: true` payload with `source: "mcp_safeguard"` and
+  `error_type: "mcp_rate_limit_{daily,monthly}_exceeded"` — unambiguously
+  distinct from a server-side Mercury 429.
 - **Optional audit trail**: `MERCURY_MCP_AUDIT_LOG=/abs/path/audit.log` writes
   an append-only JSON Lines record (file mode `0o600`, sensitive fields
   redacted) of every write call.


### PR DESCRIPTION
Updates `SECURITY.md` to describe the **dual-window** rate-limit design shipped in #49.

The previous text still described the single-window-per-category design:
> rate-limiting middleware caps write operations per category

New text covers:
- Per-bucket (not per-category) — finer granularity
- Dual-window policy (daily + 30-day rolling), and why the monthly cap matters (drain-by-pacing attack a single-day limit cannot catch)
- The structured `source: "mcp_safeguard"` / `error_type: "mcp_rate_limit_*_exceeded"` payload that distinguishes local caps from a Mercury 429

Pure docs — no code change.

[skip-readme]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated security guidance to describe per-bucket dual-window rate limits (daily and monthly), dry-run behavior, and the standardized safeguard signal format returned when limits are hit.

* **Security**
  * Clarified that rate-limit safeguard responses are distinct from server 429 errors and specify the error type for daily vs. monthly exceedances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->