### PR TITLE
Release v0.8.2 — dual-window rate limits + funding + CodeRabbit commit policy

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,16 @@
 # CodeRabbit configuration
 # Docs: https://docs.coderabbit.ai/guides/configure-coderabbit
+#
+# NOTE — CodeRabbit must NOT push commits to this repo.
+# The branch protection on main requires "approval from someone other
+# than the last pusher". On a solo-maintainer repo, a CodeRabbit-authored
+# commit makes the bot both the last pusher AND the approver, which
+# makes the rule impossible to satisfy and deadlocks the PR.
+#
+# Never use `@coderabbitai apply suggestions`, `@coderabbitai auto_commit`,
+# or click GitHub's "Commit suggestion" button on CodeRabbit inline
+# suggestions. If a suggestion is valuable, copy the diff and commit it
+# as a human — keep CodeRabbit's role strictly read-only.
 
 language: en-US
 early_access: false
@@ -9,6 +20,7 @@ reviews:
   request_changes_workflow: true
   high_level_summary: true
   poem: false                 # no decorative poetry
+  in_progress_fortune: false  # no fortune-cookie message during reviews
   review_status: true
   collapse_walkthrough: false
   abort_on_close: true
@@ -28,6 +40,14 @@ reviews:
       # function names like `enforceRateLimit` / `redactSensitive` are
       # self-documenting and a forced JSDoc would just paraphrase them.
       mode: off
+    # If a specific human reviewer is explicitly requested on a PR
+    # (via GitHub's "Reviewers" UI), CodeRabbit's own approval must NOT
+    # count as a substitute for theirs. Does not affect the common case
+    # where no specific reviewer is requested — CodeRabbit can still
+    # approve routine PRs (including Dependabot bumps) and satisfy the
+    # "approval from someone other than the last pusher" branch
+    # protection rule.
+    override_requested_reviewers_only: true
 
   path_instructions:
     - path: "src/tools/**"
@@ -47,3 +67,4 @@ reviews:
 
 chat:
   auto_reply: true
+  art: false                  # no ASCII/emoji art in chat responses

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,14 @@
-# Update if you set up sponsors. Leaving commented for now.
-# github: [klodr]
-# custom: ["https://yourdomain.com/sponsor"]
+# GitHub sponsor button configuration
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+#
+# Maintaining this MCP server (and its sibling klodr/* MCPs) is part-time
+# unpaid open-source work. If it saves you code-review time or avoids a
+# one-week security audit, funding covers the tools that make it possible
+# (Claude Code, Socket Security, CI minutes).
+#
+# Monthly recurring > one-off tips — that's how a solo maintainer can
+# commit to keeping issues triaged and security CVEs patched within 24 h.
+
+github: klodr
+patreon: klodr
+ko_fi: klodr

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     groups:
       types:
         patterns:
@@ -15,9 +15,11 @@ updates:
       production-dependencies:
         dependency-type: "production"
     commit-message:
+      # No `include: "scope"` — it would duplicate the type in the
+      # prefix ("deps(deps): …" / "deps-dev(deps-dev): …") since we
+      # already encode prod vs dev in `prefix` / `prefix-development`.
       prefix: "deps"
       prefix-development: "deps-dev"
-      include: "scope"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-04-21
+
+### Added
+
+- Funding links in `.github/FUNDING.yml` (GitHub Sponsors, Patreon,
+  Ko-fi) and matching badges at the top of the README. Monthly
+  recurring funding helps cover the tooling (Claude Code, Socket
+  Security, CI) behind steady security patches and issue triage.
+
 ### Changed (BREAKING for env overrides + state file)
 
 - **Dual-window rate limits**: every write tool now enforces both a daily
@@ -29,9 +38,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `invoicing`, …) is ignored on first load after upgrade — effectively
   a fresh 30-day window starts from the upgrade moment.
 - Rate-limit errors now return a structured JSON payload with
-  `error_type` (`daily_limit_exceeded` or `monthly_limit_exceeded`),
-  `message`, `hint`, and `retry_after` (ISO 8601 timestamp) — so the
-  agent can back off at the right granularity instead of guessing.
+  `source: "mcp_safeguard"`, `error_type` (`mcp_rate_limit_daily_exceeded`
+  or `mcp_rate_limit_monthly_exceeded`), `message`, `hint`, and
+  `retry_after` (ISO 8601 timestamp) — unambiguously distinct from a
+  server-side Mercury 429 (which surfaces separately as
+  `"Mercury API error 429: …"` via the `MercuryError` branch).
+- `.coderabbit.yaml` now carries an explicit policy NOTE forbidding
+  CodeRabbit-authored commits: on a solo-maintainer repo the branch
+  protection rule "approval from someone other than the last pusher"
+  deadlocks if the bot is both the last pusher and the approver. The
+  NOTE complements the existing
+  `pre_merge_checks.override_requested_reviewers_only: true` gate with
+  explicit human discipline (never click "Commit suggestion", never
+  run `@coderabbitai apply suggestions`).
+- `SECURITY.md` updated to describe the dual-window design and clarify
+  that `isError: true` lives on the `ToolResult` as a sibling of the
+  `content` array (set by `wrapToolHandler`), while the structured
+  JSON payload with `source` / `error_type` is inside
+  `content[0].text` (returned by `formatRateLimitError`).
+- `dependabot.yml`: drop `include: "scope"` (was producing duplicated
+  titles like `deps(deps): bump X` / `deps-dev(deps-dev): bump X`
+  because the prefix already encodes prod vs dev). Reduce
+  `open-pull-requests-limit` from 10 to 5 to keep the review queue
+  manageable.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
 [![MCP Server](https://badge.mcpx.dev?type=server 'MCP Server')](https://modelcontextprotocol.io)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/klodr/mercury-invoicing-mcp/pulls)
 
+[![Sponsor on GitHub](https://img.shields.io/github/sponsors/klodr?logo=github-sponsors&label=GitHub%20Sponsors&color=EA4AAA)](https://github.com/sponsors/klodr)
+[![Patreon](https://img.shields.io/badge/Patreon-F96854?logo=patreon&logoColor=white)](https://www.patreon.com/klodr)
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/klodr)
+
 A Model Context Protocol (MCP) server giving AI assistants (Claude, Cursor, Continue, etc.) full programmatic access to your **Mercury** business banking account, including the **Invoicing API** (one-shot + recurring) which is missing from every other Mercury MCP.
 
 ## Why this MCP?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { registerAllTools } from "./tools/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.8.1";
+export const VERSION = "0.8.2";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 export interface ServerOptions {


### PR DESCRIPTION
## Summary

Cuts the release that carries the dual-window rate-limit work merged in #49, plus the housekeeping items:

- **Dual-window rate limits** (from #49): each write tool now enforces both a daily (24h) and a monthly (30-day rolling) cap. Closes a drain-by-pacing attack that a single-day limit could not catch (7 send_money/day × 30d = 210 outbound payments that used to pass silently).
- **Structured error payload** with `source: "mcp_safeguard"` and `error_type: "mcp_rate_limit_{daily,monthly}_exceeded"`, unambiguously distinct from a real Mercury 429.
- **`SECURITY.md`** (from #50) updated to describe the dual-window design and clarify that `isError: true` is a sibling of `content` on the `ToolResult`, not inside the JSON payload.
- **`.github/FUNDING.yml`** — GitHub Sponsors funding link.
- **`.coderabbit.yaml`** — explicit NOTE forbidding CodeRabbit-authored commits (solo-maintainer branch-protection deadlock).

## Breaking (for env overrides + state file)

- Env format: `MERCURY_MCP_RATE_LIMIT_<BUCKET>=D/day,M/month` — both windows required.
- State file keys: now bucket names (`payments`, `customers_write`, …). Pre-upgrade category keys are ignored on first load.

## Test plan

- [x] `npm test` — 107/107 passing
- [x] `npm run build` / lint / prettier — clean
- [x] `npm version 0.8.2` — `sync-version.mjs` propagated to `server.json` and `src/server.ts`