### PR TITLE
chore(dependabot): ignore @types/node major + parity limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,14 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # Keep @types/node pinned on the 20.x line so its type surface
+    # tracks engines.node (>=20.11). A semver-major bump would declare
+    # APIs the runtime doesn't guarantee. Reopen only when we move the
+    # engines floor to a newer LTS.
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
     groups:
       types:
         patterns:
@@ -26,5 +34,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    open-pull-requests-limit: 5
     commit-message:
       prefix: "ci"


### PR DESCRIPTION
## Summary

Stops Dependabot from proposing `@types/node` semver-major bumps on the weekly grouped PR. The project pins `engines.node: >=20.11`, so jumping types to 24.x+ would declare APIs the runtime does not guarantee — we hit this false alarm on both mercury (PR #52, closed) and this repo.

Also adds `open-pull-requests-limit: 5` explicitly on the `github-actions` block so it mirrors the npm block (was implicitly capped — now documented).

[skip-readme]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to refine automatic dependency update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->