### PR TITLE
feat(release): sign + attach SPDX + CycloneDX SBOMs, add DCO line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,44 @@ jobs:
         with:
           subject-path: dist/index.js
 
-      - name: Attach signed artifacts to the GitHub Release
+      # SBOMs of the install-time dependency tree. syft walks the
+      # lockfile + node_modules and produces SPDX (json) + CycloneDX
+      # (json) — both shipped so downstream consumers can pick whichever
+      # their scanner speaks.
+      - name: Generate SPDX SBOM (SPDX 2.3 JSON)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: spdx-json
+          output-file: dist/sbom.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Generate CycloneDX SBOM (1.6 JSON)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: dist/sbom.cdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      # Sign both SBOMs with Sigstore (keyless, via GitHub OIDC) so
+      # downstream consumers can prove the SBOM came from THIS
+      # release-on-this-repo, not a trojaned copy.
+      - name: Sign SPDX SBOM attestation
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: dist/index.js
+          sbom-path: dist/sbom.spdx.json
+
+      - name: Sign CycloneDX SBOM attestation
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: dist/index.js
+          sbom-path: dist/sbom.cdx.json
+
+      - name: Attach signed artifacts + SBOMs to the GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
@@ -131,6 +168,8 @@ jobs:
         run: |
           test -n "${BUNDLE_PATH:-}" || { echo "Missing attestation bundle-path output"; exit 1; }
           test -f "$BUNDLE_PATH" || { echo "Bundle file not found: $BUNDLE_PATH"; exit 1; }
+          test -f dist/sbom.spdx.json || { echo "SPDX SBOM missing"; exit 1; }
+          test -f dist/sbom.cdx.json || { echo "CycloneDX SBOM missing"; exit 1; }
           # The Sigstore bundle (.sigstore) satisfies Scorecard's "signed" check (8/10).
           cp "$BUNDLE_PATH" dist/index.js.sigstore
           # The DSSE envelope inside the bundle IS the SLSA in-toto attestation.
@@ -150,6 +189,8 @@ jobs:
             dist/index.js \
             dist/index.js.sigstore \
             dist/index.js.intoto.jsonl \
+            dist/sbom.spdx.json \
+            dist/sbom.cdx.json \
             --repo "${{ github.repository }}" \
             --clobber
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,10 @@ Issues and PRs welcome. Please open an issue first for substantial changes.
 4. If you add or rename a tool, update the `Tools` section in the README and the `defineTool(server, ...)` call in `src/tools/`
 5. New write tools must be registered in `TOOL_BUCKET` + `DEFAULT_BUCKET_LIMITS` (`src/middleware.ts`) so they are rate-limited
 
+## Developer Certificate of Origin
+
+Every commit carries a `Signed-off-by:` trailer — adding it (automatic with `git commit -s` or our prepare-commit-msg hook) certifies the [DCO 1.1](https://developercertificate.org/).
+
 ## Releases (maintainers only)
 
 Do not edit `version` by hand — run `npm version patch|minor|major`. The lifecycle hook calls `scripts/sync-version.mjs` to propagate the bump into `server.json` and `src/server.ts`. Editing `package.json` directly will leave those two files out of sync.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -152,6 +152,22 @@ DSSE envelope on its own, exposed for tools (like OpenSSF Scorecard's
 Any verification failure means the artifact was not built by the
 official release pipeline — do not install it.
 
+## Software Bill of Materials (SBOM)
+
+Every GitHub Release ships two SBOMs generated from the install-time dependency tree by `anchore/sbom-action` (syft under the hood):
+
+- `sbom.spdx.json` — SPDX 2.3 JSON
+- `sbom.cdx.json` — CycloneDX 1.6 JSON
+
+Each SBOM carries its own Sigstore attestation binding it to the `dist/index.js` of the same release run. Verify with:
+
+```bash
+gh attestation verify dist/sbom.spdx.json --repo klodr/mercury-invoicing-mcp
+gh attestation verify dist/sbom.cdx.json  --repo klodr/mercury-invoicing-mcp
+```
+
+Then feed the SBOMs into `grype`, `trivy`, `dependency-track`, or any SPDX/CDX-aware scanner.
+
 ## Reporting a Vulnerability
 
 If you discover a security vulnerability in `mercury-invoicing-mcp`, please report it **privately** so we can address it before any disclosure.


### PR DESCRIPTION
## Summary

Backport of the SBOM + DCO work from:
- klodr/gmail-mcp#16
- klodr/faxdrop-mcp#50

### Release workflow (`release.yml`)

- Generates two SBOMs of the install-time dependency tree via `anchore/sbom-action@v0.24.0` (syft under the hood):
  - `dist/sbom.spdx.json` — SPDX 2.3 JSON
  - `dist/sbom.cdx.json` — CycloneDX 1.6 JSON
- Each SBOM is signed with `actions/attest-sbom@v4.1.0` (Sigstore keyless via GitHub OIDC), bound to `dist/index.js` of the same run.
- Both SBOMs are attached to the GitHub Release alongside the existing `index.js`, `index.js.sigstore`, and `index.js.intoto.jsonl`.

### Docs

- `SECURITY.md` — new **Software Bill of Materials (SBOM)** section with the `gh attestation verify` commands consumers need.
- `CONTRIBUTING.md` — one-line **Developer Certificate of Origin** reference. `Signed-off-by:` is added automatically by the global `prepare-commit-msg` hook (or `git commit -s`).

### Why

SBOMs + SBOM signatures raise the OpenSSF Scorecard `Signed-Releases` signal and let downstream scanners (`grype`, `trivy`, `dependency-track`) trust the dependency list came from this release-on-this-repo. DCO certifies the origin of every commit without requiring a full CLA workflow.

## Test plan

- [x] `yaml.safe_load` on `release.yml` (valid)
- [ ] Next `v*` tag push produces 2 SBOMs + 2 SBOM attestations on the GitHub Release
- [ ] `gh attestation verify dist/sbom.spdx.json --repo klodr/mercury-invoicing-mcp` passes post-release
- [ ] `gh attestation verify dist/sbom.cdx.json --repo klodr/mercury-invoicing-mcp` passes post-release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Software Bill of Materials (SBOM) documentation to security guide, including supported formats (SPDX 2.3 JSON, CycloneDX 1.6 JSON) and attestation verification commands.
  * Updated contribution guidelines with Developer Certificate of Origin (DCO) commit sign-off requirement.

* **Release Artifacts**
  * GitHub Releases now include SBOM files with Sigstore attestations for enhanced supply chain transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->