### PR TITLE
docs(contributing): one-line DCO reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,10 @@ Issues and PRs welcome. Please open an issue first for substantial changes.
 4. If you add or rename a tool, update the `Tools` section in the README and the `defineTool(server, ...)` call in `src/tools/`
 5. New write tools must be registered in `TOOL_BUCKET` + `DEFAULT_BUCKET_LIMITS` (`src/middleware.ts`) so they are rate-limited
 
+## Developer Certificate of Origin
+
+Every commit must carry a `Signed-off-by:` trailer to certify compliance with [DCO 1.1](https://developercertificate.org/). The trailer is added automatically by `git commit -s` or our prepare-commit-msg hook.
+
 ## Releases (maintainers only)
 
 Do not edit `version` by hand — run `npm version patch|minor|major`. The lifecycle hook calls `scripts/sync-version.mjs` to propagate the bump into `server.json` and `src/server.ts`. Editing `package.json` directly will leave those two files out of sync.


### PR DESCRIPTION
## Summary

Split out of #58 (now closed) — one-line DCO reference in `CONTRIBUTING.md`:

```
Every commit carries a `Signed-off-by:` trailer — adding it (automatic with `git commit -s` or our prepare-commit-msg hook) certifies the DCO 1.1.
```

Pairs with the global `prepare-commit-msg` hook that auto-adds the trailer locally, so certifying DCO becomes a one-shot setup per machine rather than per commit.

## Test plan

- [x] `CONTRIBUTING.md` renders on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Contribution guide updated with a Developer Certificate of Origin (DCO) 1.1 requirement. All commits must include a Signed-off-by trailer to certify authorship.
  * Clarifies contributor responsibilities and ensures recorded consent for contributions going forward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->