### PR TITLE
feat(release): sign + attach SPDX + CycloneDX SBOMs to each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,14 @@ jobs:
         env:
           NODE_ENV: production
 
+      # npm ci above runs without NODE_ENV=production, so it installs the
+      # devDependencies we need to build. Now that dist/index.js is ready,
+      # prune them so the SBOM reflects the RUNTIME dependency tree, not
+      # the build toolchain — otherwise downstream scanners flag tsup /
+      # typescript / vitest CVEs that can't reach a consumer's process.
+      - name: Prune devDependencies before SBOM generation
+        run: npm prune --omit=dev
+
       # Extract the CHANGELOG section for this version. Fail fast if missing,
       # so we never publish a version with no notes.
       - name: Extract changelog section for ${{ github.ref_name }}
@@ -123,7 +131,46 @@ jobs:
         with:
           subject-path: dist/index.js
 
-      - name: Attach signed artifacts to the GitHub Release
+      # SBOMs of the runtime dependency tree (devDependencies pruned above).
+      # syft walks the lockfile + node_modules and produces SPDX (json) +
+      # CycloneDX (json) — both shipped so downstream consumers can pick
+      # whichever their scanner speaks.
+      - name: Generate SPDX SBOM (SPDX 2.3 JSON)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: spdx-json
+          output-file: dist/sbom.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Generate CycloneDX SBOM (1.6 JSON)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: dist/sbom.cdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      # Sign both SBOMs with Sigstore (keyless, via GitHub OIDC) so
+      # downstream consumers can prove the SBOM came from THIS
+      # release-on-this-repo, not a trojaned copy. We use actions/attest
+      # (the direct action) — actions/attest-sbom is now a deprecated
+      # compatibility wrapper per GitHub's own docs.
+      - name: Sign SPDX SBOM attestation
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: dist/index.js
+          sbom-path: dist/sbom.spdx.json
+
+      - name: Sign CycloneDX SBOM attestation
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: dist/index.js
+          sbom-path: dist/sbom.cdx.json
+
+      - name: Attach signed artifacts + SBOMs to the GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
@@ -131,6 +178,8 @@ jobs:
         run: |
           test -n "${BUNDLE_PATH:-}" || { echo "Missing attestation bundle-path output"; exit 1; }
           test -f "$BUNDLE_PATH" || { echo "Bundle file not found: $BUNDLE_PATH"; exit 1; }
+          test -f dist/sbom.spdx.json || { echo "SPDX SBOM missing"; exit 1; }
+          test -f dist/sbom.cdx.json || { echo "CycloneDX SBOM missing"; exit 1; }
           # The Sigstore bundle (.sigstore) satisfies Scorecard's "signed" check (8/10).
           cp "$BUNDLE_PATH" dist/index.js.sigstore
           # The DSSE envelope inside the bundle IS the SLSA in-toto attestation.
@@ -150,6 +199,8 @@ jobs:
             dist/index.js \
             dist/index.js.sigstore \
             dist/index.js.intoto.jsonl \
+            dist/sbom.spdx.json \
+            dist/sbom.cdx.json \
             --repo "${{ github.repository }}" \
             --clobber
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -152,6 +152,31 @@ DSSE envelope on its own, exposed for tools (like OpenSSF Scorecard's
 Any verification failure means the artifact was not built by the
 official release pipeline — do not install it.
 
+## Software Bill of Materials (SBOM)
+
+Every GitHub Release ships two SBOMs generated from the **runtime** dependency tree (`devDependencies` pruned before `syft` walks the tree) by `anchore/sbom-action`:
+
+- `sbom.spdx.json` — SPDX 2.3 JSON
+- `sbom.cdx.json` — CycloneDX 1.6 JSON
+
+Each SBOM carries its own Sigstore attestation binding it to the `dist/index.js` of the same release run. The attestation subject is the artifact (`dist/index.js`), not the SBOM file itself — `gh attestation verify` therefore expects the artifact path plus an explicit `--predicate-type` selecting which SBOM flavor to check:
+
+```bash
+# Download the release artifact + SBOMs first
+gh release download v<version> --repo klodr/mercury-invoicing-mcp \
+  --pattern 'index.js' --pattern 'sbom.*.json'
+
+# SPDX
+gh attestation verify index.js --repo klodr/mercury-invoicing-mcp \
+  --predicate-type https://spdx.dev/Document/v2.3
+
+# CycloneDX
+gh attestation verify index.js --repo klodr/mercury-invoicing-mcp \
+  --predicate-type https://cyclonedx.org/bom
+```
+
+Then feed the SBOMs into `grype`, `trivy`, `dependency-track`, or any SPDX/CDX-aware scanner.
+
 ## Reporting a Vulnerability
 
 If you discover a security vulnerability in `mercury-invoicing-mcp`, please report it **privately** so we can address it before any disclosure.


### PR DESCRIPTION
## Summary

SBOM generation + signing, split out of #58 (now closed) with the 3 CodeRabbit findings applied up-front.

### release.yml

- `npm prune --omit=dev` before SBOM generation so the SBOMs reflect the **runtime** dependency tree, not the build toolchain. Previously syft would index `tsup` / `typescript` / `vitest`, which inflates downstream vuln reports for packages that can't reach a consumer's process.
- Signs each SBOM with `actions/attest@v4.1.0` (SHA `59d89421`). `actions/attest-sbom` is now a deprecated compatibility wrapper per GitHub's own docs — using the direct action future-proofs the workflow.
- Adds `sbom.spdx.json` + `sbom.cdx.json` + their attestations to each GitHub Release.

### SECURITY.md

New **Software Bill of Materials** section with **corrected** `gh attestation verify` commands:

- The subject is `dist/index.js` (per `subject-path:`), not the SBOM file. `gh attestation verify` checks the attestation against the subject; the SBOM is the attestation content.
- `gh attestation verify` defaults to SLSA provenance, so `--predicate-type https://spdx.dev/Document/v2.3` or `--predicate-type https://cyclonedx.org/bom` is required to select the right attestation.

## Test plan

- [x] `yaml.safe_load` on release.yml (valid)
- [ ] Next `v*` tag push produces 2 SBOMs + 2 SBOM attestations on the GitHub Release
- [ ] `gh attestation verify index.js --repo klodr/mercury-invoicing-mcp --predicate-type https://spdx.dev/Document/v2.3` passes post-release
- [ ] Same with `--predicate-type https://cyclonedx.org/bom`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Releases now include two SBOMs (SPDX and CycloneDX) representing runtime-only dependencies (dev dependencies pruned).
  * Each SBOM is cryptographically attested and published alongside the main release artifact with corresponding attestation bundles.

* **Documentation**
  * Security docs updated with verification examples showing how to validate attestations bound to the release artifact and how to use SBOMs with common scanners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->