### PR TITLE
chore(docker): HEALTHCHECK NONE on stdio image to silence Checkov

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,8 @@ COPY --from=build --chown=mcp:mcp /app/node_modules ./node_modules
 COPY --from=build --chown=mcp:mcp /app/dist ./dist
 COPY --from=build --chown=mcp:mcp /app/package.json ./package.json
 
-# stdio MCP: no listening sockets, no EXPOSE.
+# stdio MCP: no listening sockets, no EXPOSE. HEALTHCHECK is meaningless
+# for a stdio child process — make that explicit so scanners (Checkov
+# CKV_DOCKER_2 etc.) stop flagging it as a missing-probe finding.
+HEALTHCHECK NONE
 ENTRYPOINT ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary

Backport from klodr/gmail-mcp#21 (CodeRabbit review finding).

Adds explicit `HEALTHCHECK NONE` before the `ENTRYPOINT` in the runtime stage:

```diff
-# stdio MCP: no listening sockets, no EXPOSE.
+# stdio MCP: no listening sockets, no EXPOSE. HEALTHCHECK is meaningless
+# for a stdio child process — make that explicit so scanners (Checkov
+# CKV_DOCKER_2 etc.) stop flagging it as a missing-probe finding.
+HEALTHCHECK NONE
 ENTRYPOINT ["node", "dist/index.js"]
```

### Why

A stdio MCP container has no HTTP endpoint, no socket — nothing to probe. The MCP client spawning the container manages its lifecycle via stdin/stdout, and Docker itself tracks PID 1 liveness.

`HEALTHCHECK NONE` is Docker's explicit "no probe needed" signal:
- Prevents inheriting a probe from the base image
- Silences Checkov `CKV_DOCKER_2` ("image ships without HEALTHCHECK") which otherwise flags the build as a low-severity finding

## Test plan

- [ ] Docker build stays green
- [ ] Checkov no longer reports CKV_DOCKER_2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Disabled container health checks in the deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->