### PR TITLE
chore(roadmap): Node.js 22 migration deadline 2026-04-30

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,7 @@ Loose planning horizon of ~12 months. The MCP follows Mercury's own API surface 
 
 ## Near-term
 
+- **Node.js 22 migration — deadline 2026-04-30** — Node 20 reaches security-support EOL on April 30, 2026. Bump `engines.node` to `>=22.0.0`, retarget `tsup.config.ts` to `node22`, pin the Dockerfile to `node:22-alpine@sha256:…`, drop Node 20 from the CI matrix (keep 22/24), bump `@types/node` to `^22.x`. Blocking for any release cut after 2026-04-30.
 - **Transaction attachments** — wrap `uploadtransactionattachment`, `getattachment`, and the listing endpoints so an agent can attach receipts / invoices / supporting documents to a transaction and retrieve them back. Priority driver: bookkeeping workflows where justificatifs need to be pinned to transactions programmatically.
 - **Finer-grained per-tool gating** — today the rate-limit policy lives in `TOOL_BUCKET` with broad families (payments / customers_write / etc.). Move towards per-tool caps driven by real usage demand once we have feedback from multi-user workspaces.
 - **Scope-aware tool list filtering** — inspect the Mercury token at startup and hide tools the token cannot invoke, instead of relying on Mercury's 403 response at call time (mirrors the OAuth-scope filtering already done in `@klodr/gmail-mcp`).


### PR DESCRIPTION
## Summary

Documents the Node.js 22 migration as a tracked roadmap item with a hard deadline of **2026-04-30** (Node 20's security-support EOL).

```diff
+ - **Node.js 22 migration — deadline 2026-04-30** — Node 20 reaches
+   security-support EOL on April 30, 2026. Bump `engines.node` to
+   `>=22.0.0`, retarget `tsup.config.ts` to `node22`, pin the Dockerfile
+   to `node:22-alpine@sha256:…`, drop Node 20 from the CI matrix
+   (keep 22/24), bump `@types/node` to `^22.x`. Blocking for any
+   release cut after 2026-04-30.
```

### Scope of the future migration

- `package.json` — `engines.node: >=22.0.0`, `@types/node: ^22.x`
- `tsup.config.ts` — `target: "node22"`
- `Dockerfile` — `node:22-alpine@sha256:…` (both build and runtime stages)
- `.github/workflows/ci.yml` — matrix `["22", "24"]`, primary node `"22"`, coverage + codecov step gated on `matrix.node == '22'`
- `.github/workflows/release.yml` + `verify-release.yml` — `node-version: "22"`
- `.github/dependabot.yml` — `@types/node` version-clamp comment
- Doc refs: `README.md`, `CONTRIBUTING.md`, `llms-install.md`, `ASSURANCE_CASE.md`, `CONTINUITY.md`, `.github/ISSUE_TEMPLATE/bug_report.yml`

~10 surfaces; not bundled inside a security/feature PR because of breadth.

## Test plan

- [x] ROADMAP renders on GitHub
- [ ] Migration PR opened before 2026-04-30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added roadmap milestone mandating Node.js 22 migration by 2026-04-30, with platform updates to be completed by this deadline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->