### PR TITLE
chore(release): 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3] - 2026-04-22
+
+### Added
+
+- **Dockerfile + `.github/icon.png`** — container distribution path for the Docker MCP Registry submission. Multi-stage, `node:20-alpine` pinned by digest, non-root `mcp` user, OCI labels (`version` from build-arg), no EXPOSE, explicit `HEALTHCHECK NONE` to silence Checkov `CKV_DOCKER_2` on stdio images.
+- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, required for OpenSSF Silver.
+- **`.github/workflows/docker.yml`** — buildx + GHA cache, asserts required OCI labels + non-root `USER=mcp`, strict smoke-test of the entrypoint.
+
+### Changed
+
+- **Roadmap extracted to `ROADMAP.md`** (no longer inlined in the README) and Silver-tier wording consolidated. Purely a docs reshuffle; the repo content covered by OpenSSF Best Practices is unchanged.
+- `.github/dependabot.yml` — `@types/node` major-version-clamp comment aligned with `engines.node` floor.
+
 ## [0.8.2] - 2026-04-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { registerAllTools } from "./tools/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.8.2";
+export const VERSION = "0.8.3";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 export interface ServerOptions {


### PR DESCRIPTION
Fast-forward main to the v0.8.3 release commit. Tag already pushed and the release workflow is publishing on npm + GitHub Release.