### PR TITLE
chore(release): 0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4] - 2026-04-22
+
+### Added
+
+- **Dockerfile + `.github/icon.png`** — container distribution path for the Docker MCP Registry submission. Multi-stage, `node:20-alpine` pinned by digest, non-root `mcp` user, OCI labels (`version` from build-arg), no EXPOSE, explicit `HEALTHCHECK NONE` to silence Checkov `CKV_DOCKER_2` on stdio images.
+- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, required for OpenSSF Silver.
+- **`.github/workflows/docker.yml`** — buildx + GHA cache, asserts required OCI labels + non-root `USER=mcp`, strict smoke-test of the entrypoint.
+
+### Changed
+
+- **Roadmap extracted to `ROADMAP.md`** (no longer inlined in the README) and Silver-tier wording consolidated. Purely a docs reshuffle; the repo content covered by OpenSSF Best Practices is unchanged.
+- `.github/dependabot.yml` — `@types/node` major-version-clamp comment aligned with `engines.node` floor.
+
 ## [0.8.2] - 2026-04-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.8.2",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.8.2",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.8.2",
+  "version": "0.8.4",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.8.2",
+  "version": "0.8.4",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.8.2",
+      "version": "0.8.4",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { registerAllTools } from "./tools/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.8.2";
+export const VERSION = "0.8.4";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 export interface ServerOptions {


### PR DESCRIPTION
## Summary

Clean-room replacement for the retracted **0.8.3** (unpublished from npm within the 72h window to drop legacy author emails from its commit metadata).

Content identical to 0.8.3 — renumbered under 0.8.4 to keep npm / tag histories coherent.

## Changes (carried from 0.8.3)

- **Dockerfile + icon + docker.yml** — container distribution path for the Docker MCP Registry submission
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 (OpenSSF Silver requirement)
- **SPDX + CycloneDX SBOMs** signed with `actions/attest@v4` (not the deprecated attest-sbom wrapper), with `id: attest_spdx`/`id: attest_cdx` so the `.sigstore` bundles are captured and uploaded
- **`npm publish --ignore-scripts`** — avoids running prepublishOnly after the devDep prune
- **Roadmap** extracted to ROADMAP.md + Silver wording consolidated
- Dependabot `@types/node` clamp aligned with engines.node

## Release hygiene

Tag `v0.8.3` was deleted and npm version 0.8.3 unpublished before this PR was opened; tagging will happen on `v0.8.4` after this PR merges.

## Test plan

- [x] yaml.safe_load on release.yml
- [x] CHANGELOG [0.8.4] section matches npm notes format
- [x] package.json + server.json + src/server.ts synced to 0.8.4
- [ ] Tag v0.8.4 push triggers release workflow
- [ ] .sigstore bundles land on the GitHub Release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker containerization support with automated build workflows

* **Documentation**
  * Added Code of Conduct for community guidelines
  * Restructured documentation with extracted roadmap

* **Chores**
  * Version bumped to 0.8.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->