### PR TITLE
chore(release): 0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.6] - 2026-04-22
+
+### Changed
+
+Republish of 0.8.5 with the CHANGELOG and Release narrative reformulated so they no longer quote the maintainer's personal email addresses verbatim. No code, schema, or runtime behaviour change — `dist/index.js` is byte-equivalent to what 0.8.5 shipped. 0.8.5 is withdrawn: GitHub Release deleted, npm version unpublished within the 72-hour window.
+
 ## [0.8.5] - 2026-04-22
 
 ### Security & privacy — clean-slate republish
 
+**Withdrawn** — superseded by 0.8.6. The CHANGELOG and Release body of this version quoted the maintainer's personal email addresses verbatim, which partly defeated the privacy migration this release was supposed to enact.
+
 This release supersedes **all** prior 0.x versions of `mercury-invoicing-mcp`. The reasons are strictly hygiene, not a change in the wire-level behaviour consumers rely on:
 
-- **Commit-metadata privacy**: `main` was historically authored under two of the maintainer's personal email addresses (`claude@altixia.com`, `claude@perrin.it`). Both are now legitimate on the maintainer's GitHub account but exposed the individual more than necessary. `main` has been rewritten so that every commit, every `Signed-off-by:` trailer, and every `Co-authored-by:` line carries `klodr@users.noreply.github.com` instead. 101 of the 101 commits on the new `main` carry a verified SSH signature; 95 are authored by the maintainer, 6 by Dependabot.
+- **Commit-metadata privacy**: `main` was historically authored under two of the maintainer's personal email addresses. `main` has been rewritten so that every commit, every `Signed-off-by:` trailer, and every `Co-authored-by:` line carries `klodr@users.noreply.github.com` instead. 101 of the 101 commits on the new `main` carry a verified SSH signature; 95 are authored by the maintainer, 6 by Dependabot.
 - **Supply-chain contract actually deliverable**: the `SECURITY.md` of earlier releases advertised SBOM attestations verifiable with `gh attestation verify --predicate-type https://spdx.dev/Document/v2.3`. That was never true on 0.8.4 and earlier — the two `actions/attest` steps lacked `id:` fields, so their signed `.sigstore` bundles were never captured and never uploaded. Starting with 0.8.5 the promise is actually met: the bundles are referenced via `${{ steps.attest_spdx.outputs.bundle-path }}` / `${{ steps.attest_cdx.outputs.bundle-path }}`, copied to `dist/sbom.spdx.sigstore` / `dist/sbom.cdx.sigstore`, and uploaded to the Release alongside the JSON SBOMs.
 - **npm `--ignore-scripts` on publish**: the `prepublishOnly` build hook needs `tsc`/`tsup`, which the earlier `npm prune --omit=dev` step (run before SBOM generation) removes. `npm publish --access public --provenance --ignore-scripts` now skips the redundant re-build — the dist/ artefact produced earlier in the job is what ships, with its own Sigstore signature.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { registerAllTools } from "./tools/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.8.5";
+export const VERSION = "0.8.6";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 export interface ServerOptions {


### PR DESCRIPTION
## Summary

Republish of 0.8.5 with the CHANGELOG and Release narrative reformulated so they no longer quote the maintainer's personal email addresses verbatim. No code, schema, or runtime behaviour change — `dist/index.js` is byte-equivalent to what 0.8.5 shipped.

0.8.5 is withdrawn: GitHub Release deleted, npm version unpublished within the 72-hour window.

## Scope

- `CHANGELOG.md`: new `[0.8.6]` section, `[0.8.5]` marked withdrawn with the personal emails stripped from the narrative
- `package.json`, `package-lock.json`, `server.json`, `src/server.ts`: version bumped 0.8.5 → 0.8.6

## Test plan

- [x] `npm test` — 107 tests passing
- [x] Versions synchronized across package.json / server.json / src/server.ts / package-lock.json
- [x] `grep -rn "altixia\|perrin" CHANGELOG.md` — clean
- [ ] After merge: tag `v0.8.6` → release workflow → npm publish + Sigstore + SBOM attestations
- [ ] Delete GitHub Release `v0.8.5`
- [ ] `npm unpublish mercury-invoicing-mcp@0.8.5`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Released version 0.8.6 as a re-release with no code, schema, or runtime behavior changes.
  * Previous version withdrawn from distribution.

* **Documentation**
  * Updated release narrative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->