### PR TITLE
fix(security): 0.8.6 — republish 0.8.5 without personal emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-Republish of 0.8.5. The CHANGELOG `[0.8.5]` narrative and the GitHub Release body for v0.8.5 originally quoted the maintainer's personal email addresses verbatim, which partly defeated the privacy migration 0.8.5 was meant to enact. `main` has since been corrected in place; 0.8.6 ships the corrected CHANGELOG to npm. No code, schema, or runtime behaviour change — `dist/index.js` is byte-equivalent to what 0.8.5 shipped. 0.8.5 is withdrawn: GitHub Release deleted, npm version unpublished within the 72-hour window.
+Republish of 0.8.5. The CHANGELOG `[0.8.5]` narrative and the GitHub Release body for v0.8.5 originally quoted the maintainer's personal email addresses verbatim, which partly defeated the privacy migration 0.8.5 was meant to enact. `main` has since been corrected in place; 0.8.6 ships the corrected CHANGELOG to npm. No code, schema, or runtime behaviour change — `dist/index.js` is byte-equivalent to what 0.8.5 shipped. 0.8.5 will be withdrawn once 0.8.6 is published: the GitHub Release will be deleted and the npm version will be unpublished (within the 72-hour window).
 
 ## [0.8.5] - 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.6] - 2026-04-22
+
+### Changed
+
+Republish of 0.8.5. The CHANGELOG `[0.8.5]` narrative and the GitHub Release body for v0.8.5 originally quoted the maintainer's personal email addresses verbatim, which partly defeated the privacy migration 0.8.5 was meant to enact. `main` has since been corrected in place; 0.8.6 ships the corrected CHANGELOG to npm. No code, schema, or runtime behaviour change — `dist/index.js` is byte-equivalent to what 0.8.5 shipped. 0.8.5 is withdrawn: GitHub Release deleted, npm version unpublished within the 72-hour window.
+
 ## [0.8.5] - 2026-04-22
 
 ### Security & privacy — clean-slate republish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { registerAllTools } from "./tools/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.8.5";
+export const VERSION = "0.8.6";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 export interface ServerOptions {


### PR DESCRIPTION
## Summary

Republish of 0.8.5 without the maintainer's personal email addresses in the CHANGELOG narrative. `main` was amended in place (`618f4c8` → `8032566`) to strip the emails from the `[0.8.5]` section; this PR bumps to 0.8.6 so npm can ship the corrected metadata (0.8.5 is already published and immutable on npm apart from the 72-hour unpublish window).

No code, schema, or runtime behaviour change — `dist/index.js` is byte-equivalent to what 0.8.5 shipped.

## Scope

- `CHANGELOG.md`: new `[0.8.6]` section explaining the republish; `[0.8.5]` stays as-is (already cleaned by the amend on main)
- `package.json`, `package-lock.json`, `server.json`, `src/server.ts`: version bumped 0.8.5 → 0.8.6

## Test plan

- [x] `npm test` — 107 tests passing
- [x] Versions synchronized across package.json / server.json / src/server.ts / package-lock.json
- [x] `grep -rn "altixia\|perrin" CHANGELOG.md` — clean
- [ ] After merge: tag `v0.8.6` → release workflow → npm publish + Sigstore + SBOM attestations
- [ ] Delete GitHub Release `v0.8.5` (body still has the personal emails, assets Sigstore perdus mais remplacés par v0.8.6)
- [ ] Delete tag `v0.8.5` (orphelin, pointait sur `618f4c8` réécrit)
- [ ] `npm unpublish mercury-invoicing-mcp@0.8.5` (fenêtre 72h)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released v0.8.6 as a republication of v0.8.5 with corrected changelog content (removed verbatim personal email addresses).
  * Package and server version metadata updated to v0.8.6; published build artifacts are byte-equivalent to the prior release and exhibit no runtime or schema changes.
  * Plan in place to withdraw the original v0.8.5 release after v0.8.6 is published.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->