### PR TITLE
fix(webhooks): enforce HTTPS + block private IPs on webhook URL (M-01)

### DIFF
--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -11,6 +11,83 @@ const eventTypesDescription = `Event types to subscribe to. Common values:
 - recipient.created / recipient.updated
 Check https://docs.mercury.com/reference/webhooks for the full list.`;
 
+/**
+ * Webhook URL validator — HTTPS only, public hostnames only.
+ *
+ * Defense-in-depth layer. Mercury almost certainly runs its own
+ * URL checks upstream (HTTPS enforcement, signed payloads per
+ * https://docs.mercury.com/reference/webhooks — payload follows
+ * JSON Merge Patch RFC 7396, typically signed to prove origin),
+ * but relying only on upstream validation means a prompt-injected
+ * request first reaches Mercury with a hostile URL before anything
+ * gets rejected. Validating at the MCP boundary stops those requests
+ * from being issued in the first place, keeps exfiltration attempts
+ * out of Mercury's audit trail, and makes the failure message visible
+ * to the operator rather than buried in a generic 400 from upstream.
+ *
+ * Rationale for the specific rules:
+ *
+ *   - HTTPS required: a prompt-injected agent that can reach the
+ *     write API of this MCP could otherwise register a webhook toward
+ *     `http://attacker.tld` and siphon every subsequent Mercury event
+ *     (transactions, invoices, balances) in clear. The
+ *     `webhooks_create: 2/day` rate limit is not a real brake here —
+ *     two endpoints are more than enough to exfiltrate. The old
+ *     `z.string().url()` accepted `http://`, `file://`, `data:`,
+ *     `ftp://`, etc.; the description said "HTTPS" but the validator
+ *     did not enforce it.
+ *
+ *   - Loopback / RFC 1918 / link-local / cloud-metadata / private IPv6
+ *     blocked: guards against operator misconfiguration (e.g. a
+ *     webhook accidentally pointing at `https://169.254.169.254/...`)
+ *     and against prompt injections that try to bounce through an
+ *     internal service. Mercury's own retries would not reach those
+ *     targets from the outside anyway, so this rule costs the caller
+ *     nothing legitimate.
+ */
+const HttpsWebhookUrl = z
+  .string()
+  .url()
+  .refine(
+    (raw) => {
+      try {
+        return new URL(raw).protocol === "https:";
+      } catch {
+        return false;
+      }
+    },
+    { message: "Webhook URL must use https:// (http, file, data, ftp, etc. are rejected)" },
+  )
+  .refine(
+    (raw) => {
+      let h: string;
+      try {
+        h = new URL(raw).hostname.toLowerCase();
+      } catch {
+        return false;
+      }
+      if (h === "localhost" || h === "127.0.0.1" || h === "::1") return false;
+      if (h.startsWith("169.254.")) return false; // link-local + AWS/GCP/Azure metadata
+      if (h.startsWith("10.")) return false; // RFC 1918 private
+      if (h.startsWith("192.168.")) return false; // RFC 1918 private
+      // RFC 1918: 172.16.0.0 – 172.31.255.255
+      if (h.startsWith("172.")) {
+        const second = Number(h.split(".")[1]);
+        if (second >= 16 && second <= 31) return false;
+      }
+      // IPv6: fc00::/7 (ULA) and fe80::/10 (link-local)
+      if (h.startsWith("[")) {
+        const v6 = h.slice(1, -1);
+        if (v6.startsWith("fc") || v6.startsWith("fd") || v6.startsWith("fe80:")) return false;
+      }
+      return true;
+    },
+    {
+      message:
+        "Webhook URL must be publicly reachable. Loopback, RFC 1918 private, link-local, cloud-metadata, and private IPv6 ranges are rejected to prevent data exfiltration and SSRF.",
+    },
+  );
+
 export function registerWebhookTools(server: McpServer, client: MercuryClient): void {
   defineTool(
     server,
@@ -39,9 +116,11 @@ export function registerWebhookTools(server: McpServer, client: MercuryClient): 
   defineTool(
     server,
     "mercury_create_webhook",
-    "Register a new webhook endpoint. Mercury will POST events as JSON to the provided URL.",
+    "Register a new webhook endpoint. Mercury will POST events as JSON to the provided URL. URL MUST use https:// on a publicly reachable host.",
     {
-      url: z.string().url().describe("HTTPS URL that will receive webhook events (POST)"),
+      url: HttpsWebhookUrl.describe(
+        "Publicly reachable HTTPS URL that will receive webhook events (POST). Must not be a loopback, private, or link-local address.",
+      ),
       events: z.array(z.string()).describe(eventTypesDescription),
     },
     async ({ url, events }) => {
@@ -56,7 +135,9 @@ export function registerWebhookTools(server: McpServer, client: MercuryClient): 
     "Update an existing webhook endpoint (URL, status, or events). Mercury endpoint is POST /webhooks/{id}. A webhook disabled after consecutive failures can be reactivated by setting status to 'active'.",
     {
       webhookId: z.string().uuid().describe("The webhook endpoint ID"),
-      url: z.string().url().optional().describe("New HTTPS URL"),
+      url: HttpsWebhookUrl.optional().describe(
+        "New publicly reachable HTTPS URL (same rules as mercury_create_webhook).",
+      ),
       status: z.enum(["active", "paused"]).optional().describe("Webhook status"),
       eventTypes: z.array(z.string()).optional().describe(eventTypesDescription),
     },

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -66,20 +66,41 @@ const HttpsWebhookUrl = z
       } catch {
         return false;
       }
-      if (h === "localhost" || h === "127.0.0.1" || h === "::1") return false;
-      if (h.startsWith("169.254.")) return false; // link-local + AWS/GCP/Azure metadata
-      if (h.startsWith("10.")) return false; // RFC 1918 private
-      if (h.startsWith("192.168.")) return false; // RFC 1918 private
-      // RFC 1918: 172.16.0.0 – 172.31.255.255
-      if (h.startsWith("172.")) {
-        const second = Number(h.split(".")[1]);
-        if (second >= 16 && second <= 31) return false;
+      // Unwrap bracketed IPv6 literals. `URL().hostname` keeps the brackets
+      // for IPv6 ([::1], [fe80::1]) — strip them before range checks.
+      const host = h.startsWith("[") && h.endsWith("]") ? h.slice(1, -1) : h;
+      if (host === "localhost" || host === "::1") return false;
+
+      // IPv4: match literal a.b.c.d and reject loopback (127/8),
+      // link-local (169.254/16), and the RFC 1918 ranges. startsWith()
+      // based checks were insufficient — "127.0.0.2" bypassed the old
+      // exact-match on "127.0.0.1", and "10." matches "10." but not
+      // correctly masks higher ranges. Numeric CIDR matching fixes both.
+      const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+      if (ipv4) {
+        const a = Number(ipv4[1]);
+        const b = Number(ipv4[2]);
+        if (
+          a === 127 || //                            127.0.0.0/8    loopback
+          a === 10 || //                             10.0.0.0/8     RFC 1918
+          (a === 169 && b === 254) || //             169.254.0.0/16 link-local + cloud metadata
+          (a === 192 && b === 168) || //             192.168.0.0/16 RFC 1918
+          (a === 172 && b >= 16 && b <= 31) //       172.16.0.0/12  RFC 1918
+        ) {
+          return false;
+        }
       }
-      // IPv6: fc00::/7 (ULA) and fe80::/10 (link-local)
-      if (h.startsWith("[")) {
-        const v6 = h.slice(1, -1);
-        if (v6.startsWith("fc") || v6.startsWith("fd") || v6.startsWith("fe80:")) return false;
+
+      // IPv6 CIDR bitmask check on the first hextet:
+      //   fc00::/7  → first 7 bits = 0b1111110 → mask 0xfe00, match 0xfc00
+      //   fe80::/10 → first 10 bits = 0b1111111010 → mask 0xffc0, match 0xfe80
+      // The old string-prefix check missed fe90..febf (still inside fe80::/10).
+      const firstHextet = Number.parseInt(host.split(":")[0] ?? "", 16);
+      if (!Number.isNaN(firstHextet)) {
+        if ((firstHextet & 0xfe00) === 0xfc00) return false; // fc00::/7 (ULA)
+        if ((firstHextet & 0xffc0) === 0xfe80) return false; // fe80::/10 (link-local)
       }
+
       return true;
     },
     {

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -89,6 +89,7 @@ const HttpsWebhookUrl = z
         const a = Number(ipv4[1]);
         const b = Number(ipv4[2]);
         if (
+          a === 0 || //                              0.0.0.0/8      "this host"/unspecified — some stacks resolve it to loopback
           a === 127 || //                            127.0.0.0/8    loopback
           a === 10 || //                             10.0.0.0/8     RFC 1918
           (a === 169 && b === 254) || //             169.254.0.0/16 link-local + cloud metadata

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -53,6 +53,10 @@ const HttpsWebhookUrl = z
       try {
         return new URL(raw).protocol === "https:";
       } catch {
+        // `z.string().url()` rejects malformed URLs before this refine
+        // runs, so `new URL()` cannot actually throw here. Kept
+        // defensive in case the upstream validator changes.
+        /* v8 ignore next */
         return false;
       }
     },
@@ -64,6 +68,10 @@ const HttpsWebhookUrl = z
       try {
         h = new URL(raw).hostname.toLowerCase();
       } catch {
+        // Same reason as above: `new URL()` cannot throw at this
+        // point because the upstream `.url()` check already rejected
+        // malformed inputs.
+        /* v8 ignore next */
         return false;
       }
       // Unwrap bracketed IPv6 literals. `URL().hostname` keeps the brackets
@@ -95,7 +103,10 @@ const HttpsWebhookUrl = z
       //   fc00::/7  → first 7 bits = 0b1111110 → mask 0xfe00, match 0xfc00
       //   fe80::/10 → first 10 bits = 0b1111111010 → mask 0xffc0, match 0xfe80
       // The old string-prefix check missed fe90..febf (still inside fe80::/10).
-      const firstHextet = Number.parseInt(host.split(":")[0] ?? "", 16);
+      // `String.split(":")[0]` always returns a defined string (possibly
+      // empty), so the nullish-coalesce that used to sit here was dead
+      // code and showed up as an uncovered branch on Codecov.
+      const firstHextet = Number.parseInt(host.split(":")[0], 16);
       if (!Number.isNaN(firstHextet)) {
         if ((firstHextet & 0xfe00) === 0xfc00) return false; // fc00::/7 (ULA)
         if ((firstHextet & 0xffc0) === 0xfe80) return false; // fe80::/10 (link-local)

--- a/test/webhooks.test.ts
+++ b/test/webhooks.test.ts
@@ -9,7 +9,13 @@ import { registerWebhookTools } from "../src/tools/webhooks.js";
 // MercuryClient issues a request) return a deterministic stub response
 // instead of actually reaching api.mercury.com and failing on a fake
 // API key. Keeps the suite network-independent and fast.
+//
+// Also disable the local rate limiter: the CIDR-adjacency case loops
+// through six public IPs and the `webhooks_create` bucket is only 2/day,
+// so without this toggle the 3rd call would see `mcp_rate_limit_daily_exceeded`
+// instead of reaching the 401 stub that proves validation actually passed.
 beforeEach(() => {
+  process.env.MERCURY_MCP_RATE_LIMIT_DISABLE = "true";
   vi.stubGlobal(
     "fetch",
     vi.fn(
@@ -23,6 +29,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  delete process.env.MERCURY_MCP_RATE_LIMIT_DISABLE;
   vi.unstubAllGlobals();
 });
 
@@ -133,6 +140,10 @@ describe("mercury_create_webhook — URL validation", () => {
       const text = (r.content as Array<{ text: string }>)[0]?.text ?? "";
       expect(text.toLowerCase(), `should have accepted ${u}`).not.toContain("publicly reachable");
       expect(text.toLowerCase(), `should have accepted ${u}`).not.toContain("must use https");
+      // Positive assertion: schema passed → MercuryClient was called and
+      // failed on the 401 stub, proving we actually reached the downstream
+      // path instead of short-circuiting on a false-negative validation pass.
+      expect(text, `should have reached downstream for ${u}`).toContain("401");
     }
   });
 

--- a/test/webhooks.test.ts
+++ b/test/webhooks.test.ts
@@ -89,6 +89,9 @@ describe("mercury_create_webhook — URL validation", () => {
       "https://127.0.0.1/hook",
       "https://127.0.0.2/hook",
       "https://127.1.2.3/hook",
+      // 0.0.0.0/8 — "this host"/unspecified
+      "https://0.0.0.0/hook",
+      "https://0.1.2.3/hook",
       // 10.0.0.0/8
       "https://10.0.0.5/hook",
       "https://10.255.255.255/hook",
@@ -159,6 +162,10 @@ describe("mercury_create_webhook — URL validation", () => {
     const text = (r.content as Array<{ text: string }>)[0]?.text ?? "";
     expect(text.toLowerCase()).not.toContain("https://");
     expect(text.toLowerCase()).not.toContain("publicly reachable");
+    // Positive mirror of the CIDR-adjacency test: the 401 stub is what
+    // proves we actually reached the MercuryClient instead of silently
+    // passing through on a false-positive validation.
+    expect(text).toContain("401");
   });
 });
 

--- a/test/webhooks.test.ts
+++ b/test/webhooks.test.ts
@@ -1,9 +1,30 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { MercuryClient } from "../src/client.js";
 import { registerWebhookTools } from "../src/tools/webhooks.js";
+
+// Mock `fetch` globally so the non-validation test cases (schema passes →
+// MercuryClient issues a request) return a deterministic stub response
+// instead of actually reaching api.mercury.com and failing on a fake
+// API key. Keeps the suite network-independent and fast.
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(
+      async () =>
+        new Response(JSON.stringify({ message: "Unauthorized" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+    ),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 /**
  * End-to-end guard against the "webhook URL accepts http://" finding.
@@ -53,19 +74,32 @@ describe("mercury_create_webhook — URL validation", () => {
     }
   });
 
-  it("rejects HTTPS URLs pointing at loopback / private / link-local IPs", async () => {
+  it("rejects HTTPS URLs pointing at loopback / private / link-local IPs (full CIDR ranges)", async () => {
     const c = await connect();
     const bad = [
       "https://localhost/hook",
+      // 127.0.0.0/8 — full loopback range, not just 127.0.0.1
       "https://127.0.0.1/hook",
-      "https://169.254.169.254/latest/meta-data/", // AWS/GCP/Azure metadata
+      "https://127.0.0.2/hook",
+      "https://127.1.2.3/hook",
+      // 10.0.0.0/8
       "https://10.0.0.5/hook",
+      "https://10.255.255.255/hook",
+      // 169.254.0.0/16 — link-local + AWS/GCP/Azure metadata
+      "https://169.254.169.254/latest/meta-data/",
+      "https://169.254.0.1/hook",
+      // 192.168.0.0/16
       "https://192.168.1.1/hook",
+      // 172.16.0.0/12 (172.16.x.x – 172.31.x.x)
       "https://172.16.0.1/hook",
       "https://172.31.255.255/hook",
+      // IPv6 loopback + ULA (fc00::/7: fc.. + fd..) + link-local (fe80::/10: fe80 – febf)
       "https://[::1]/hook",
       "https://[fc00::1]/hook",
+      "https://[fd00::1]/hook",
       "https://[fe80::1]/hook",
+      "https://[fe90::1]/hook", // still inside fe80::/10 — the old startsWith("fe80:") missed this
+      "https://[febf:ffff::1]/hook", // last /16 inside fe80::/10
     ];
     for (const u of bad) {
       const r = await c.callTool({
@@ -73,6 +107,32 @@ describe("mercury_create_webhook — URL validation", () => {
         arguments: { url: u, events: ["invoice.paid"] },
       });
       expect(r.isError, `should have rejected ${u}`).toBe(true);
+    }
+  });
+
+  it("accepts IPv4 addresses adjacent to but outside the blocked CIDR ranges", async () => {
+    const c = await connect();
+    // These are publicly routable and must NOT trip the private-IP filter.
+    // Schema passes → request reaches Mercury → fails on fake API key
+    // (expected; the point is that the schema let it through).
+    const good = [
+      "https://128.0.0.1/hook", //     next /8 after 127
+      "https://11.0.0.1/hook", //      next /8 after 10
+      "https://172.15.255.255/hook", // 172.15.x.x is public (12-block starts at .16)
+      "https://172.32.0.1/hook", //    172.32.x.x is public (12-block ends at .31)
+      "https://192.167.1.1/hook", //   just below 192.168
+      "https://169.253.0.1/hook", //   just below 169.254
+    ];
+    for (const u of good) {
+      const r = await c.callTool({
+        name: "mercury_create_webhook",
+        arguments: { url: u, events: ["invoice.paid"] },
+      });
+      // If the schema wrongly rejected these, the error would mention
+      // "publicly reachable" or "must use https" — assert it does NOT.
+      const text = (r.content as Array<{ text: string }>)[0]?.text ?? "";
+      expect(text.toLowerCase(), `should have accepted ${u}`).not.toContain("publicly reachable");
+      expect(text.toLowerCase(), `should have accepted ${u}`).not.toContain("must use https");
     }
   });
 

--- a/test/webhooks.test.ts
+++ b/test/webhooks.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { MercuryClient } from "../src/client.js";
+import { registerWebhookTools } from "../src/tools/webhooks.js";
+
+/**
+ * End-to-end guard against the "webhook URL accepts http://" finding.
+ * Exercises the Zod schema through the MCP wire so a refactor that
+ * relocates the validator can still be caught.
+ */
+async function connect() {
+  const server = new McpServer({ name: "test", version: "0.0.0" });
+  const client = new MercuryClient({ apiKey: "test-key-not-used-in-validation-path" });
+  registerWebhookTools(server, client);
+
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  const mcpClient = new Client({ name: "test", version: "0.0.0" }, { capabilities: {} });
+  await Promise.all([mcpClient.connect(clientT), server.connect(serverT)]);
+  return mcpClient;
+}
+
+describe("mercury_create_webhook — URL validation", () => {
+  it("rejects http:// URLs", async () => {
+    const c = await connect();
+    const r = await c.callTool({
+      name: "mercury_create_webhook",
+      arguments: { url: "http://example.com/hook", events: ["invoice.paid"] },
+    });
+    expect(r.isError).toBe(true);
+    const text = (r.content as Array<{ text: string }>)[0]?.text ?? "";
+    expect(text.toLowerCase()).toMatch(/https/);
+  });
+
+  it("rejects file:// URLs", async () => {
+    const c = await connect();
+    const r = await c.callTool({
+      name: "mercury_create_webhook",
+      arguments: { url: "file:///etc/passwd", events: ["invoice.paid"] },
+    });
+    expect(r.isError).toBe(true);
+  });
+
+  it("rejects data: and ftp: schemes", async () => {
+    const c = await connect();
+    for (const bad of ["data:text/plain,payload", "ftp://example.com/hook"]) {
+      const r = await c.callTool({
+        name: "mercury_create_webhook",
+        arguments: { url: bad, events: ["invoice.paid"] },
+      });
+      expect(r.isError).toBe(true);
+    }
+  });
+
+  it("rejects HTTPS URLs pointing at loopback / private / link-local IPs", async () => {
+    const c = await connect();
+    const bad = [
+      "https://localhost/hook",
+      "https://127.0.0.1/hook",
+      "https://169.254.169.254/latest/meta-data/", // AWS/GCP/Azure metadata
+      "https://10.0.0.5/hook",
+      "https://192.168.1.1/hook",
+      "https://172.16.0.1/hook",
+      "https://172.31.255.255/hook",
+      "https://[::1]/hook",
+      "https://[fc00::1]/hook",
+      "https://[fe80::1]/hook",
+    ];
+    for (const u of bad) {
+      const r = await c.callTool({
+        name: "mercury_create_webhook",
+        arguments: { url: u, events: ["invoice.paid"] },
+      });
+      expect(r.isError, `should have rejected ${u}`).toBe(true);
+    }
+  });
+
+  it("accepts HTTPS URLs pointing at public hostnames (validation passes; downstream API call fails on the fake key, which is expected)", async () => {
+    const c = await connect();
+    const r = await c.callTool({
+      name: "mercury_create_webhook",
+      arguments: { url: "https://hooks.example.com/mercury", events: ["invoice.paid"] },
+    });
+    // Validation passed → control reached the Mercury client, which fails
+    // with an auth error on the fake API key. The key point: the error is
+    // an upstream Mercury one, not a Zod schema rejection.
+    const text = (r.content as Array<{ text: string }>)[0]?.text ?? "";
+    expect(text.toLowerCase()).not.toContain("https://");
+    expect(text.toLowerCase()).not.toContain("publicly reachable");
+  });
+});
+
+describe("mercury_update_webhook — URL validation (same rules)", () => {
+  it("rejects http:// on update too", async () => {
+    const c = await connect();
+    const r = await c.callTool({
+      name: "mercury_update_webhook",
+      arguments: {
+        webhookId: "00000000-0000-4000-8000-000000000000",
+        url: "http://example.com/hook",
+      },
+    });
+    expect(r.isError).toBe(true);
+  });
+
+  it("rejects metadata IPs on update too", async () => {
+    const c = await connect();
+    const r = await c.callTool({
+      name: "mercury_update_webhook",
+      arguments: {
+        webhookId: "00000000-0000-4000-8000-000000000000",
+        url: "https://169.254.169.254/latest/meta-data/",
+      },
+    });
+    expect(r.isError).toBe(true);
+  });
+
+  it("update without url arg still works (url is optional)", async () => {
+    const c = await connect();
+    const r = await c.callTool({
+      name: "mercury_update_webhook",
+      arguments: {
+        webhookId: "00000000-0000-4000-8000-000000000000",
+        status: "paused",
+      },
+    });
+    // Validation passed; downstream API call will fail (fake key) but not on schema.
+    const text = (r.content as Array<{ text: string }>)[0]?.text ?? "";
+    expect(text.toLowerCase()).not.toContain("https://");
+  });
+});

--- a/test/webhooks.test.ts
+++ b/test/webhooks.test.ts
@@ -14,7 +14,14 @@ import { registerWebhookTools } from "../src/tools/webhooks.js";
 // through six public IPs and the `webhooks_create` bucket is only 2/day,
 // so without this toggle the 3rd call would see `mcp_rate_limit_daily_exceeded`
 // instead of reaching the 401 stub that proves validation actually passed.
+let prevRateLimitDisable: string | undefined;
+
 beforeEach(() => {
+  // Snapshot-and-restore instead of blindly deleting — the test runner
+  // may already have MERCURY_MCP_RATE_LIMIT_DISABLE set (e.g. via a
+  // global setup or CI env), and clobbering it on every `afterEach`
+  // would leak a mutation beyond this file.
+  prevRateLimitDisable = process.env.MERCURY_MCP_RATE_LIMIT_DISABLE;
   process.env.MERCURY_MCP_RATE_LIMIT_DISABLE = "true";
   vi.stubGlobal(
     "fetch",
@@ -29,7 +36,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  delete process.env.MERCURY_MCP_RATE_LIMIT_DISABLE;
+  if (prevRateLimitDisable === undefined) {
+    delete process.env.MERCURY_MCP_RATE_LIMIT_DISABLE;
+  } else {
+    process.env.MERCURY_MCP_RATE_LIMIT_DISABLE = prevRateLimitDisable;
+  }
   vi.unstubAllGlobals();
 });
 
@@ -206,5 +217,10 @@ describe("mercury_update_webhook — URL validation (same rules)", () => {
     // Validation passed; downstream API call will fail (fake key) but not on schema.
     const text = (r.content as Array<{ text: string }>)[0]?.text ?? "";
     expect(text.toLowerCase()).not.toContain("https://");
+    expect(text.toLowerCase()).not.toContain("publicly reachable");
+    // Positive mirror of the create-webhook acceptance tests: the 401
+    // stub is what proves we reached MercuryClient, not that some other
+    // silent failure let the test pass.
+    expect(text).toContain("401");
   });
 });


### PR DESCRIPTION
## Summary

Closes M-01 from a prompt-injection threat review: \`z.string().url()\` on \`mercury_create_webhook\` and \`mercury_update_webhook\` accepted \`http://\`, \`file://\`, \`data:\`, \`ftp://\`, etc. Description said *\"HTTPS URL\"* but the validator did not enforce it.

## Threat

A prompt-injected agent reaching the write API could register a webhook toward \`http://attacker.tld\` and siphon every subsequent Mercury event (transactions, invoices, balances) in clear. The \`webhooks_create: 2/day\` rate limit does not help — two hostile endpoints are more than enough to exfiltrate.

## Fix

Applied to both \`mercury_create_webhook\` and \`mercury_update_webhook\` (via a shared \`HttpsWebhookUrl\` validator):

- **HTTPS required** — \`http\`, \`file\`, \`data\`, \`ftp\`, \`javascript\`, … rejected
- **Hostnames rejected**:
  - Loopback: \`localhost\`, \`127.0.0.1\`, \`::1\`
  - RFC 1918 private: \`10.0.0.0/8\`, \`172.16.0.0/12\`, \`192.168.0.0/16\`
  - Link-local / cloud-metadata: \`169.254.0.0/16\` (AWS/GCP/Azure metadata endpoint)
  - Private IPv6: \`fc00::/7\`, \`fe80::/10\`

## Defense-in-depth positioning

Mercury almost certainly runs its own URL checks upstream (webhooks are signed per the docs, following RFC 7396 JSON Merge Patch for payloads). Validating at the MCP boundary is additive: hostile requests never reach Mercury, exfiltration attempts stay out of the upstream audit trail, and the rejection is visible locally instead of a generic upstream 400.

## Test plan

- [x] \`npm test\` — 115 tests passing (107 before + 8 new on webhook URL validation)
- [x] 8 new end-to-end tests via \`InMemoryTransport\`:
  - \`http://\` rejected on create + update
  - \`file://\`, \`data:\`, \`ftp://\` rejected
  - 10 different private-range hostnames rejected (incl. \`169.254.169.254\`)
  - Public HTTPS URL passes schema
  - Update without \`url\` arg still works (url is optional on update)
- [x] \`npm run lint\` — clean
- [x] \`npm run format:check\` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook URL validation is stricter: only HTTPS URLs are accepted; URLs resolving to localhost, loopback, private, link-local, cloud-metadata or other restricted IP ranges are rejected. Tool descriptions updated to reflect HTTPS/public-reachability requirements.
* **Tests**
  * Added end-to-end tests validating create/update URL rules: rejecting disallowed schemes/IPs, accepting public hosts and adjacent IPs, and confirming updates work when URL is omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->