### PR TITLE
ci(qodo): add dual reviewer (DeepSeek R1 + Gemini 3.1) via Qodo Merge

### DIFF
--- a/.github/workflows/qodo-merge.yml
+++ b/.github/workflows/qodo-merge.yml
@@ -14,11 +14,15 @@ name: Qodo Merge (dual reviewer)
 # author's PR description, /improve produces commitable suggestions which
 # block merges for a solo maintainer (see feedback_coderabbit_no_auto_commit).
 #
-# Reasoning budget: both models are explicit reasoning models with
-# `CONFIG__REASONING_EFFORT=high` so they spend actual thinking tokens
-# on the diff instead of glancing at it. Takes longer (~40-90s/job) and
-# costs more per review, but that's the whole point of running a second
-# reviewer tier — otherwise we're paying for a glorified grep.
+# Reasoning: both models reason natively — DeepSeek R1 has built-in
+# chain-of-thought, Gemini 3.1 Pro Preview runs with thinking mode on
+# by default on Google AI Studio. pr-agent v0.34's `reasoning_effort`
+# config is whitelisted to OpenAI `o3`/`o4-mini` models only
+# (SUPPORT_REASONING_EFFORT_MODELS) and its `litellm.extra_body` hook
+# accepts only `processing_mode`/`service_tier` — no supported path to
+# inject a custom `thinking_level=high` on Gemini here. TODO: revisit
+# when pr-agent adds Gemini 3.x thinking controls natively or when we
+# move to a fork that exposes the litellm thinking_config passthrough.
 
 on:
   pull_request:
@@ -51,7 +55,6 @@ jobs:
           # diff rather than pattern-matching on surface syntax.
           CONFIG__MODEL: deepseek/deepseek-reasoner
           CONFIG__FALLBACK_MODELS: '["deepseek/deepseek-reasoner"]'
-          CONFIG__REASONING_EFFORT: high
           DEEPSEEK__KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           GITHUB_ACTION_CONFIG__AUTO_REVIEW: "true"
           GITHUB_ACTION_CONFIG__AUTO_DESCRIBE: "false"
@@ -80,7 +83,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONFIG__MODEL: gemini/gemini-3.1-pro-preview
           CONFIG__FALLBACK_MODELS: '["gemini/gemini-3-pro-preview"]'
-          CONFIG__REASONING_EFFORT: high
           GOOGLE_AI_STUDIO__GEMINI_API_KEY: ${{ secrets.GOOGLE_AI_STUDIO_API_KEY }}
           GITHUB_ACTION_CONFIG__AUTO_REVIEW: "true"
           GITHUB_ACTION_CONFIG__AUTO_DESCRIBE: "false"

--- a/.github/workflows/qodo-merge.yml
+++ b/.github/workflows/qodo-merge.yml
@@ -1,0 +1,90 @@
+name: Qodo Merge (dual reviewer)
+
+# Runs two parallel AI reviews via qodo-ai/pr-agent — one with DeepSeek
+# R1 (reasoner) and one with Gemini 3.1 Pro Preview (thinking mode).
+# Both post under `qodo-ai[bot]` with a distinct `[DeepSeek]` / `[Gemini]`
+# prefix so they can be disambiguated in the UI.
+#
+# Intentional complement to CodeRabbit: triangulates findings with 3
+# independent model families (GPT via CR, DeepSeek R1, Gemini 3.1 Pro)
+# rather than re-reading the same diff with the same lineage.
+# See project_qodo_dual_reviewer_plan.md.
+#
+# Scope: only the /review tool is enabled — /describe would overwrite the
+# author's PR description, /improve produces commitable suggestions which
+# block merges for a solo maintainer (see feedback_coderabbit_no_auto_commit).
+#
+# Reasoning budget: both models are explicit reasoning models with
+# `CONFIG__REASONING_EFFORT=high` so they spend actual thinking tokens
+# on the diff instead of glancing at it. Takes longer (~40-90s/job) and
+# costs more per review, but that's the whole point of running a second
+# reviewer tier — otherwise we're paying for a glorified grep.
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  # Cancel in-flight runs on push — only the latest commit's review matters.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  qodo-deepseek:
+    name: Qodo review (DeepSeek R1)
+    runs-on: ubuntu-latest
+    # Skip drafts unless explicitly marked ready; they're noisy and the
+    # API cost isn't useful while the PR is still being drafted.
+    if: ${{ !github.event.pull_request.draft }}
+    steps:
+      - name: PR Agent — DeepSeek R1 (reasoner)
+        uses: qodo-ai/pr-agent@d82f7d3e696cd00822694aaa3096265d3889f3f1 # v0.34
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # deepseek-reasoner = R1, explicit chain-of-thought. Slower and
+          # pricier than deepseek-chat but actually reasons through the
+          # diff rather than pattern-matching on surface syntax.
+          CONFIG__MODEL: deepseek/deepseek-reasoner
+          CONFIG__FALLBACK_MODELS: '["deepseek/deepseek-reasoner"]'
+          CONFIG__REASONING_EFFORT: high
+          DEEPSEEK__KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          GITHUB_ACTION_CONFIG__AUTO_REVIEW: "true"
+          GITHUB_ACTION_CONFIG__AUTO_DESCRIBE: "false"
+          GITHUB_ACTION_CONFIG__AUTO_IMPROVE: "false"
+          # Default pr_actions excludes `synchronize` → subsequent pushes
+          # would be silently skipped. Include it so each new commit
+          # triggers a fresh review (aligned with the workflow's `on:`).
+          GITHUB_ACTION_CONFIG__PR_ACTIONS: '["opened", "reopened", "ready_for_review", "synchronize"]'
+          # With persistent_comment=true, both jobs detect each other's
+          # comment via the same HTML marker and the second run overwrites
+          # the first — we'd only ever see one of the two reviews. Disable
+          # persistence so each model's review lands in its own comment.
+          PR_REVIEWER__PERSISTENT_COMMENT: "false"
+          # Prefix every review with [DeepSeek] so the two jobs can be
+          # told apart in the PR timeline (both post as qodo-ai[bot]).
+          PR_REVIEWER__EXTRA_INSTRUCTIONS: "Prefix the review title with '[DeepSeek R1]'."
+
+  qodo-gemini:
+    name: Qodo review (Gemini 3.1 Pro)
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    steps:
+      - name: PR Agent — Gemini 3.1 Pro Preview (thinking)
+        uses: qodo-ai/pr-agent@d82f7d3e696cd00822694aaa3096265d3889f3f1 # v0.34
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONFIG__MODEL: gemini/gemini-3.1-pro-preview
+          CONFIG__FALLBACK_MODELS: '["gemini/gemini-3-pro-preview"]'
+          CONFIG__REASONING_EFFORT: high
+          GOOGLE_AI_STUDIO__GEMINI_API_KEY: ${{ secrets.GOOGLE_AI_STUDIO_API_KEY }}
+          GITHUB_ACTION_CONFIG__AUTO_REVIEW: "true"
+          GITHUB_ACTION_CONFIG__AUTO_DESCRIBE: "false"
+          GITHUB_ACTION_CONFIG__AUTO_IMPROVE: "false"
+          GITHUB_ACTION_CONFIG__PR_ACTIONS: '["opened", "reopened", "ready_for_review", "synchronize"]'
+          PR_REVIEWER__PERSISTENT_COMMENT: "false"
+          PR_REVIEWER__EXTRA_INSTRUCTIONS: "Prefix the review title with '[Gemini 3.1 Pro]'."

--- a/.github/workflows/qodo-merge.yml
+++ b/.github/workflows/qodo-merge.yml
@@ -42,9 +42,14 @@ jobs:
   qodo-deepseek:
     name: Qodo review (DeepSeek R1)
     runs-on: ubuntu-latest
-    # Skip drafts unless explicitly marked ready; they're noisy and the
-    # API cost isn't useful while the PR is still being drafted.
-    if: ${{ !github.event.pull_request.draft }}
+    # Cap at 15 min — a reasoning model call should never take more than
+    # a couple of minutes; anything beyond that is a hung connection
+    # burning runner time.
+    timeout-minutes: 15
+    # Skip drafts (noisy while drafting) and fork PRs (repository secrets
+    # are not exposed to fork PRs — the job would run and fail on empty
+    # DEEPSEEK_API_KEY, creating a red check for no reason).
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: PR Agent — DeepSeek R1 (reasoner)
         uses: qodo-ai/pr-agent@d82f7d3e696cd00822694aaa3096265d3889f3f1 # v0.34
@@ -75,7 +80,8 @@ jobs:
   qodo-gemini:
     name: Qodo review (Gemini 3.1 Pro)
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
+    timeout-minutes: 15
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: PR Agent — Gemini 3.1 Pro Preview (thinking)
         uses: qodo-ai/pr-agent@d82f7d3e696cd00822694aaa3096265d3889f3f1 # v0.34


### PR DESCRIPTION
## Summary

Backport of [klodr/gmail-mcp#31](https://github.com/klodr/gmail-mcp/pull/31) (Qodo Merge dual reviewer POC, validated).

Two parallel AI reviews on every PR via `qodo-ai/pr-agent@v0.34` (pinned by SHA):
- **DeepSeek R1** (`deepseek/deepseek-reasoner`) — explicit chain-of-thought reasoning
- **Gemini 3.1 Pro Preview** — native thinking mode

Both with `CONFIG__REASONING_EFFORT=high` — these are reasoning models, so they spend actual thinking tokens on the diff rather than pattern-matching surface syntax. Complements CodeRabbit (GPT lineage) by triangulating findings with three independent model families.

## What's enforced

- Trigger: `pull_request` on `opened, reopened, ready_for_review, synchronize`
- Drafts skipped (no API burn on in-progress work)
- `/review` only — `/describe` would overwrite the PR description, `/improve` produces commitable suggestions that block merges for solo maintainers
- `persistent_comment=false` so each model's review lands in its own comment (otherwise the second job detects the first's HTML marker and overwrites it)
- Concurrency group cancels in-flight runs on new push

## Secrets required

- `DEEPSEEK_API_KEY`
- `GOOGLE_AI_STUDIO_API_KEY`

Already set on this repo.

## Test plan

- [ ] Qodo Merge workflow runs 2 parallel jobs (DeepSeek R1 + Gemini 3.1 Pro)
- [ ] Both reviews post as independent comments with distinct `[DeepSeek R1]` / `[Gemini 3.1 Pro]` prefixes
- [ ] Per-job logs show `REASONING_EFFORT=high` applied, no rate-limit errors, no "model not in MAX_TOKENS" errors
- [ ] No leaked secrets in the action logs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established automated pull request review workflow triggered on PR events and new commits
  * Dual reviewer system running in parallel with distinct configurations
  * Each review prefixed with reviewer identifier for easy identification
  * Automated reviews skip draft PRs and repository forks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->