### PR TITLE
chore(release): v0.9.0 (external reviewer + M-01/M-02 fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-22
+
+### Added
+
+- **External AI review tier** via Qodo Merge (`.github/workflows/qodo-merge.yml`). Every PR now gets three independent AI reviews in parallel: CodeRabbit (GPT lineage), DeepSeek R1 (reasoner, explicit chain-of-thought), and Gemini 3.1 Pro Preview (thinking mode). `qodo-ai/pr-agent@v0.34` pinned by SHA, `/review` only (no auto-description, no commitable suggestions), fork PRs and drafts skipped, 15-min timeout, `persistent_comment=false` so each model lands its own comment. Triangulates findings across three model families — the failure mode of one lineage is rarely the failure mode of the others.
+
+### Security
+
+- **Webhook URL validator tightened** (M-01). `mercury_create_webhook` / `mercury_update_webhook` now require `https://` and reject any hostname that resolves to a loopback, RFC 1918 private, link-local, cloud-metadata, or private-IPv6 range — IPv4 via numeric CIDR match (`127/8`, `10/8`, `169.254/16`, `192.168/16`, `172.16/12`, plus `0.0.0.0/8`), IPv6 via bitmask on the first hextet (`fc00::/7`, `fe80::/10`). The previous `z.string().url()` let `http://`, `file://`, `data:`, `ftp://` through even though the tool description said HTTPS. A prompt-injected agent that reached the webhook API of this MCP would otherwise have registered `http://attacker.tld` and siphoned every subsequent Mercury event (transactions, invoices, balances) in clear. Defense-in-depth: Mercury almost certainly validates upstream too, but validating here keeps the hostile URL out of Mercury's audit trail and surfaces the failure to the operator instead of a generic 400.
+- **LLM ping-pong injection sanitized** (M-02). Every JSON value returned by the Mercury API is walked and stripped of ASCII control characters, zero-width characters (U+200B-U+200F, U+202A-U+202E, U+2060, U+FEFF), BiDi control marks, and the BOM before reaching the LLM. Errors are fenced in a `<untrusted-tool-output>` block so a prompt embedded inside an invoice description, a recipient name, or a transaction memo cannot hijack the tool-calling agent by echoing back crafted instructions. JSON structure is preserved verbatim — no double-wrapping, no lossy re-encoding.
+- **Local write rate limiter** visible in audit: `webhooks_create` caps at 2/day by default. The test suite exercises `MERCURY_MCP_RATE_LIMIT_DISABLE=true` via a snapshot-and-restore pattern so a shared env var set by the test runner survives the run.
+
 ## [0.8.6] - 2026-04-22
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.8.6",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.8.6",
+      "version": "0.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { registerAllTools } from "./tools/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.8.6";
+export const VERSION = "0.9.0";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 export interface ServerOptions {


### PR DESCRIPTION
## Summary

Bumps mercury-invoicing-mcp 0.8.6 → 0.9.0. Highlights:

- **External AI review tier**: Qodo Merge workflow (DeepSeek R1 + Gemini 3.1 Pro Preview) runs in parallel with CodeRabbit on every PR. Three independent model lineages, one failure mode each.
- **M-01 fix**: webhook URL validator now enforces `https://` + blocks loopback / RFC 1918 / link-local / cloud-metadata / private-IPv6 ranges (numeric CIDR + IPv6 bitmask). Closes the exfiltration vector where a prompt-injected agent could register `http://attacker.tld` and stream Mercury events in clear.
- **M-02 fix**: every Mercury API response value is stripped of ASCII control, zero-width, BiDi, BOM before reaching the LLM; errors are fenced in `<untrusted-tool-output>`. JSON format preserved verbatim.

## Test plan

- [ ] Tag `v0.9.0` pushed after merge triggers `release.yml` → Sigstore-signed `dist/index.js` + SLSA attestation + SPDX/CycloneDX SBOM bundles + `npm publish --access public --provenance`.
- [ ] `mercury-invoicing-mcp@0.9.0` visible on npmjs.com with provenance badge.
- [ ] `npm audit signatures` reports verified attestation on the new version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External AI review tier with parallel automated reviews per PR.

* **Security**
  * Enhanced webhook URL validation requiring HTTPS and rejecting private/loopback addresses.
  * Sanitized API JSON outputs.
  * Rate limiting for webhook creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->