### PR TITLE
chore(release): v0.9.1 (Node 22 migration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-04-22
+
+Single focus: move the whole toolchain off Node 20 ahead of its 2026-04-30 end-of-life. Not a feature release — `dist/index.js` behaviour is unchanged versus 0.9.0.
+
 ### Changed (BREAKING)
 
 - **Node.js floor: `>=22`** (was `>=20.11`). Node 20 reaches end-of-life on 2026-04-30; keeping the floor there would ship 0.9.0-era packages on an unmaintained runtime the day after. Node 22 is in Maintenance LTS through 2027-04-30, which gives a year of headroom before the next cadence bump.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { registerAllTools } from "./tools/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.9.0";
+export const VERSION = "0.9.1";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 export interface ServerOptions {


### PR DESCRIPTION
## Summary

Bumps mercury-invoicing-mcp from 0.9.0 to 0.9.1. Single focus: shipping the Node 22 migration that landed via #72 so the npm package actually carries the new floor ahead of Node 20 leaving Active LTS on 2026-04-30.

No runtime/behaviour change vs 0.9.0 — `dist/index.js` is functionally identical, just recompiled against Node 22 / ES2024 targets.

## On npm after this PR

- `engines.node >=22`
- `tsup target: node22`
- `tsconfig target: ES2024` (+ matching `lib`)
- `@types/node ^22.19.17`
- `.nvmrc` with `22`
- CI / release / verify-release workflows all on Node 22
- Dockerfile pinned to `node:22-alpine@sha256:8ea2348b068a…`
- README / SECURITY / ROADMAP / CHANGELOG / CONTINUITY / ASSURANCE_CASE / issue templates / dependabot all scrubbed of stray Node 20 refs (with corrected Maintenance LTS terminology vs upstream nodejs/Release schedule)

## Test plan

- [x] `npm test` — 138/138 on Node 24 locally
- [ ] CI green on this PR (Node 22 + 24)
- [ ] Tag `v0.9.1` pushed after merge triggers `release.yml` — Sigstore + SLSA + SPDX + CycloneDX all signed
- [ ] `npm view mercury-invoicing-mcp@0.9.1 dist.attestations` returns SLSA v1 provenance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.9.1 with Node.js toolchain support upgraded from version 20 to version 22.
  * Maintenance-focused release with no changes to features, functionality, or behavior compared to 0.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->