### PR TITLE
chore(glama): claim ownership on glama.ai via glama.json

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["klodr"]
+}


### PR DESCRIPTION
## Summary

Adds a minimal `glama.json` at the repo root so the `klodr` GitHub account can claim and maintain the Glama MCP directory listing for this server.

```json
{
  "$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": ["klodr"]
}
```

Per the [Glama spec](https://glama.ai/blog/2025-07-08-what-is-glamajson), the file only declares ownership — name/description/Docker card/etc. are edited through the Glama web UI after claim. The `Claim` flow on glama.ai needs to be re-triggered once this lands on `main` to resync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration settings for internal project infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->