### PR TITLE
chore(node): tighten engines floor to >=22.11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     # Keep @types/node pinned on the 22.x line so its type surface
-    # tracks engines.node (>=22). A semver-major bump would declare
+    # tracks engines.node (>=22.11). A semver-major bump would declare
     # APIs the runtime doesn't guarantee. Reopen only when we move the
     # engines floor to a newer LTS.
     ignore:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,9 @@
+# Enforce engines.node locally: `npm install` on a Node older than the
+# declared floor fails immediately instead of warning. Without this the
+# engines field is metadata only. Keeps local dev aligned with CI (Node
+# 22 + 24 matrix) and catches accidental installs on a rogue Node.
+# Downstream consumers of the published tarball still get npm's default
+# advisory behaviour unless they set engine-strict in their own config —
+# that's the npm ecosystem norm, and a preinstall script would give
+# false security (a hostile user can --ignore-scripts it anyway).
+engine-strict=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Node.js floor tightened to `>=22.11`** (was `>=22`). `22.11.0` is the LTS-tagged entry point for the Node 22 "Jod" line (October 2024); the previous `>=22` would have accepted the pre-LTS `22.0`–`22.10` releases which predate the LTS designation. Aligned with the sibling repos `klodr/faxdrop-mcp` and `klodr/gmail-mcp`, all moving to the same floor.
 - `.github/dependabot.yml` `@types/node` major-version-clamp comment aligned to the new `>=22.11` floor.
+- `llms-install.md` prerequisite updated to **Node.js ≥ 22.11**.
+- `SECURITY.md` "Supported runtimes" section updated to state `Node.js ≥ 22.11` with the LTS-tag rationale.
 
 ## [0.9.1] - 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Node.js floor tightened to `>=22.11`** (was `>=22`). `22.11.0` is the LTS-tagged entry point for the Node 22 "Jod" line (October 2024); the previous `>=22` would have accepted the pre-LTS `22.0`–`22.10` releases which predate the LTS designation. Aligned with the sibling repos `klodr/faxdrop-mcp` and `klodr/gmail-mcp`, all moving to the same floor.
+- `.github/dependabot.yml` `@types/node` major-version-clamp comment aligned to the new `>=22.11` floor.
+
 ## [0.9.1] - 2026-04-22
 
 Single focus: move the whole toolchain off Node 20 ahead of its 2026-04-30 end-of-life. Not a feature release — `dist/index.js` behaviour is unchanged versus 0.9.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.github/dependabot.yml` `@types/node` major-version-clamp comment aligned to the new `>=22.11` floor.
 - `llms-install.md` prerequisite updated to **Node.js ≥ 22.11**.
 - `SECURITY.md` "Supported runtimes" section updated to state `Node.js ≥ 22.11` with the LTS-tag rationale.
+- `README.md` comparison table gained a **Node.js floor** row making the three-way posture explicit (hosted N/A, `dragonkhoi/mercury-mcp` ships without `engines.node` so installs silently on Node 14 EOL, `mercury-invoicing-mcp` enforces `>=22.11` at the manifest level).
 
 ## [0.9.1] - 2026-04-22
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A Model Context Protocol (MCP) server giving AI assistants (Claude, Cursor, Cont
 | Built-in safeguards (rate limit, dry-run, redacted audit log) | ❌ | ❌ | ✅ |
 | Hosted (no token to manage) | ✅ | ❌ | ❌ |
 | Open source (MIT) | ❌ | ✅ | ✅ |
+| Node.js floor | N/A (hosted) | ❌ from Node 14 EOL (2023) | ✅ Active LTS (`>=22.11`) |
 | Total tools exposed | ~10 | ~11 | **34** |
 
 For pure read-only consultation, prefer the [official Mercury MCP](https://docs.mercury.com/docs/what-is-mercury-mcp). Use this one when you need to **automate invoicing, write to Mercury, or expose Mercury to LLM agents safely**.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -102,7 +102,7 @@ maintainer commits to, and limits that callers must account for.
 
 ## Supported runtimes
 
-`mercury-invoicing-mcp` supports **Node.js ≥ 22** (Maintenance LTS, supported through 2027-04-30). Releases prior to 0.9.1 shipped with a `>=20.11` floor; releases cut from 2026-04-30 onward require Node 22+ because Node 20 reaches end-of-life on 2026-04-30. Older pinned versions of the package remain installable but will not receive back-ported security fixes.
+`mercury-invoicing-mcp` supports **Node.js ≥ 22.11** (the LTS-tagged entry point of the Node 22 "Jod" line, October 2024; in Maintenance LTS through 2027-04-30). Releases prior to 0.9.1 shipped with a `>=20.11` floor; releases cut from 2026-04-30 onward require Node 22.11+ because Node 20 reaches end-of-life on 2026-04-30 and the `>=22.11` floor skips the pre-LTS 22.0–22.10 releases that predate the LTS designation. Older pinned versions of the package remain installable but will not receive back-ported security fixes.
 
 ## Verifying releases
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -7,7 +7,7 @@ client that can launch a stdio child process can use this server.
 
 ## Prerequisites the assistant should verify
 
-1. **Node.js ≥ 22** is installed (`node --version`).
+1. **Node.js ≥ 22.11** is installed (`node --version`).
 2. **npx** is on `PATH` (ships with Node).
 3. The user has — or is willing to create — a **Mercury API token** at
    <https://app.mercury.com/settings/tokens>. Tokens look like

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "vitest": "^4.1.4"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=22.11"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prepublishOnly": "NODE_ENV=production npm run build"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.11"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary

Tighten `engines.node` from `>=22` to `>=22.11` to pin on the LTS-tagged entry point of the Node 22 "Jod" line (October 2024). The previous `>=22` floor accepted `22.0`–`22.10` — pre-LTS releases that predate the LTS designation.

## Why

The v0.9.1 Node 22 migration used `>=22` for simplicity. Today while aligning the three `klodr/*` MCP servers, tightening to `>=22.11` matches the tight-specific-minor style that `faxdrop-mcp` had historically (`>=20.11`) and gives all three repos a single, consistent Node engine contract.

## Changes

- `package.json` engines: `>=22.11` (was `>=22`).
- `.github/dependabot.yml` `@types/node` major-clamp comment aligned.

## Test plan

- [x] `npm install` — 0 vulnerabilities.
- [x] `npm run test` — 138 / 138 passing.
- [ ] CI (lint, build matrix 22 + 24, CodeQL, Socket, Snyk).
- [ ] CodeRabbit + Qodo dual reviewers.

## Companion PRs

- klodr/gmail-mcp#45 — same tightening.
- klodr/faxdrop-mcp#63 — same tightening bundled into its Node 22 migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Node.js runtime requirement from `>=22` to `>=22.11` across project configuration and all supporting documentation.
  * Clarified Node.js version support policies and updated installation prerequisites to align with the new requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->