### PR TITLE
chore(coverage): rename istanbul ignore → v8 ignore

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -374,7 +374,7 @@ export function wrapToolHandler<TArgs>(
             isError: true,
           };
         }
-        /* istanbul ignore next -- defensive: enforceRateLimit only ever
+        /* v8 ignore next -- defensive: enforceRateLimit only ever
            throws RateLimitError today; this re-throw guards against a
            future regression that would surface as a programming bug, not
            a runtime path we can exercise from a unit test. */

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -148,9 +148,10 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
       } = current;
       const merged: Record<string, unknown> = { ...editable };
       for (const [k, v] of Object.entries(changes)) {
-        /* istanbul ignore else -- Zod-validated args never carry undefined
-           values (optional keys are elided), so the false branch is a
-           defensive guard rather than a runtime path we can hit. */
+        // Zod-validated args never carry undefined values (optional keys
+        // are elided), so the false branch is a defensive guard rather
+        // than a runtime path we can hit.
+        /* v8 ignore next */
         if (v !== undefined) merged[k] = v;
       }
       const data = await client.post(`/ar/invoices/${invoiceId}`, merged);


### PR DESCRIPTION
## Summary

Two `/* istanbul ignore */` markers were invisible to V8 coverage: `vitest.config.ts` uses the v8 provider, which only honours `/* v8 ignore next */`. Rename so the annotated defensive branches stop showing up as uncovered.

- `src/middleware.ts:377` — re-throw after RateLimitError catch (only ever reached on a programming-error re-classification of the thrown type; not exercisable from unit tests).
- `src/tools/invoices.ts:151` — Zod-elided-undefined guard (optional keys never carry `undefined` after Zod validation; defensive check).

No code-behaviour change.