### PR TITLE
feat(codecov): wire Test Analytics (JUnit + test-results-action)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,11 @@ jobs:
           fail_ci_if_error: false
           slug: klodr/mercury-invoicing-mcp
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results to Codecov (Test Analytics)
+        if: matrix.node == '22' && !cancelled()
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        with:
+          files: ./test-results.junit.xml
+          slug: klodr/mercury-invoicing-mcp
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov (Test Analytics)
-        if: matrix.node == '22' && !cancelled()
+        if: ${{ always() && matrix.node == '22' && !cancelled() }}
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           report_type: test_results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,10 @@ jobs:
 
       - name: Upload test results to Codecov (Test Analytics)
         if: matrix.node == '22' && !cancelled()
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
+          report_type: test_results
           files: ./test-results.junit.xml
+          fail_ci_if_error: false
           slug: klodr/mercury-invoicing-mcp
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 !.env.example
 .DS_Store
 coverage
+test-results.junit.xml
 .idea
 .vscode
 *.tsbuildinfo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Codecov Test Analytics wiring** — vitest emits a `test-results.junit.xml` alongside its default human reporter, and the CI run uploads it to Codecov via `codecov/test-results-action@v1.2.1` (pinned by SHA). Gives us the "Tests" dashboard on codecov.io: per-suite flaky-test detection, slowest tests, test failure history. Upload runs only on the Node 22 matrix leg with `!cancelled()` so a test failure still surfaces the report. XML file is in `.gitignore` and excluded from the published tarball (not in `package.json#files`).
+
 ## [0.9.1] - 2026-04-22
 
 Single focus: move the whole toolchain off Node 20 ahead of its 2026-04-30 end-of-life. Not a feature release — `dist/index.js` behaviour is unchanged versus 0.9.0.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
     include: ["test/**/*.test.ts"],
     setupFiles: ["test/setup.ts"],
     restoreMocks: true,
+    // Keep the default human-readable reporter and ALSO emit a JUnit XML
+    // file for Codecov Test Analytics (flaky / slow test detection over
+    // time). Regenerated every run; gitignored.
+    reporters: ["default", ["junit", { outputFile: "test-results.junit.xml" }]],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],


### PR DESCRIPTION
## Summary

Adds [Codecov Test Analytics](https://docs.codecov.com/docs/test-analytics) to the CI flow. Vitest emits a JUnit XML on every run; CI uploads it alongside the existing coverage report.

## Changes

- `vitest.config.ts` — add a `junit` reporter in addition to the default human-readable one, output to `test-results.junit.xml`.
- `.github/workflows/ci.yml` — new `codecov/test-results-action@v1.2.1` step (pinned by full SHA `0fa95f0e`), gated on Node 22 matrix leg with `!cancelled()` so a test failure still surfaces the report.
- `.gitignore` — ignore `test-results.junit.xml`.
- `CHANGELOG.md` `[Unreleased]` — Added bullet.

## What it unlocks

- **Flaky-test detection** — tests that alternate pass/fail in CI get flagged with a stability percentage.
- **Slowest tests** — per-suite ranking to spot the tests that eat the most CI minutes.
- **Failure history** per individual test.
- Dashboard: `https://app.codecov.io/gh/klodr/mercury-invoicing-mcp/tests`.

## Test plan

- [x] `npm run test` — 138 / 138 passing, `test-results.junit.xml` materialised.
- [x] `npx prettier --check vitest.config.ts .github/workflows/ci.yml`.
- [ ] CI (lint, build, CodeQL, Socket, Snyk).
- [ ] CodeRabbit.
- [ ] Qodo dual reviewers.
- [ ] Codecov Tests dashboard shows a first run after merge.

## Why the SHA pin

`codecov/test-results-action` is a third-party OIDC-capable action; pinning by full commit SHA matches the policy already in effect for every other Action in this repo's workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* CI pipeline now generates JUnit-formatted test results and automatically uploads them to Codecov, enabling enhanced test analytics including flaky test detection, performance analysis, and failure history tracking on the Codecov dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->