### PR TITLE
chore(release): 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.2] - 2026-04-23
+
+### Fixed
+
+- **CodeQL Code Scanning alert #28** (`src/sanitize.ts`) — the control-character stripping regex is now spelled with explicit `\uXXXX` escapes instead of literal C0/C1 characters embedded in the source. Functionally identical, but the literal form tripped CodeQL's "invisible Unicode" rule. No runtime behaviour change.
+- **CI `Upload test results to Codecov` guard** — the step now reads `if: ${{ always() && matrix.node == '22' && !cancelled() }}`. The prior `if: matrix.node == '22' && !cancelled()` was ambiguous: `!cancelled()` alone does replace the implicit `success()` check in GitHub Actions expression semantics, but the ambiguity is enough that failed test runs were at risk of being filtered out of Test Analytics — defeating the entire point of the upload (seeing flaky-test patterns on red builds). Explicit `always()` makes the "upload on failure" behaviour load-bearing in the YAML itself.
+- **README CodeRabbit badge URL** — dropped the `utm_source=oss&utm_medium=github&utm_campaign=klodr%2Fmercury-invoicing-mcp&` prefix from the `img.shields.io/coderabbit/prs/...` badge URL. Those params are what CodeRabbit's "embed this badge" snippet proposes by default, but shields.io doesn't interpret them — they only serve to give the URL a unique signature from the other sibling-repo badges, which means GitHub's camo image proxy caches each variant independently. When the upstream CodeRabbit endpoint returned a transient `provider or repo not found` at camo's initial fetch, that error SVG got cached and kept rendering while the sibling-repo badge (with a different URL) rendered fine. Dropping the utm params aligns the badge URL with the form used on `klodr/gmail-mcp` and invalidates the stale camo cache on the next README render.
 
 ### Changed
 
@@ -14,10 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `llms-install.md` prerequisite updated to **Node.js ≥ 22.11**.
 - `SECURITY.md` "Supported runtimes" section updated to state `Node.js ≥ 22.11` with the LTS-tag rationale.
 - `README.md` comparison table gained a **Node.js floor** row making the three-way posture explicit (hosted N/A, `dragonkhoi/mercury-mcp` ships without `engines.node` so installs silently on Node 14 EOL, `mercury-invoicing-mcp` enforces `>=22.11` at the manifest level).
+- **Coverage ignore comments renamed from `/* istanbul ignore next */` to `/* v8 ignore next */`** to match the V8 coverage provider actually used under vitest. Functionally identical; aligns the syntax with the tool doing the work.
 
 ### Added
 
 - **Codecov Test Analytics wiring** — vitest emits a `test-results.junit.xml` alongside its default human reporter, and the CI run uploads it to Codecov via `codecov/codecov-action@v6.0.0` (pinned by SHA) invoked with `report_type: test_results` — the standalone `codecov/test-results-action@v1.2.1` is deprecated in favour of the unified action. Gives us the "Tests" dashboard on codecov.io: per-suite flaky-test detection, slowest tests, test failure history. Upload runs only on the Node 22 matrix leg with `!cancelled()` so a test failure still surfaces the report. XML file is in `.gitignore` and excluded from the published tarball (not in `package.json#files`).
+- **`glama.json` at the repo root** — claims ownership of the `klodr/mercury-invoicing-mcp` listing on glama.ai (MCP server registry), so the automated scanner pairs the listing with this repo rather than an unclaimed fork.
 
 ## [0.9.1] - 2026-04-22
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/klodr/mercury-invoicing-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/klodr/mercury-invoicing-mcp)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12575/badge)](https://www.bestpractices.dev/projects/12575)
 [![Socket Security](https://socket.dev/api/badge/npm/package/mercury-invoicing-mcp)](https://socket.dev/npm/package/mercury-invoicing-mcp)
-[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/klodr/mercury-invoicing-mcp?utm_source=oss&utm_medium=github&utm_campaign=klodr%2Fmercury-invoicing-mcp&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
+[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/klodr/mercury-invoicing-mcp?labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
 
 [![npm version](https://img.shields.io/npm/v/mercury-invoicing-mcp.svg)](https://www.npmjs.com/package/mercury-invoicing-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/mercury-invoicing-mcp.svg)](https://www.npmjs.com/package/mercury-invoicing-mcp)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { registerAllTools } from "./tools/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.9.1";
+export const VERSION = "0.9.2";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 export interface ServerOptions {


### PR DESCRIPTION
## Summary

Cuts release **v0.9.2** — wraps the five PRs that landed on `main` since 0.9.1:

- **fix(sanitize)**: CodeQL #28 — control-char regex respelled with `\uXXXX` escapes (#75)
- **chore(glama)**: `glama.json` for glama.ai ownership claim (#74)
- **chore(node)**: engines floor tightened to `>=22.11` (#76)
- **chore(coverage)**: istanbul-ignore comments renamed to v8-ignore (#77)
- **feat(codecov)**: Test Analytics wiring (JUnit + `codecov-action@v6` with `report_type: test_results`) (#78)
- **fix(ci)**: `always()` guard on the test-results upload step (part of #78 in-PR)
- **chore(readme)**: drop `utm_*` params from CodeRabbit badge URL — aligns with `klodr/gmail-mcp`'s form, invalidates a stale camo cache on github.com that had pinned a transient `provider or repo not found` SVG.

Version bumped via `npm version 0.9.2 --no-git-tag-version` → `package.json`/`package-lock.json`/`server.json`/`src/server.ts` sync'd by the repo's `scripts/sync-version.mjs` hook. CHANGELOG section rename `Unreleased` → `[0.9.2] - 2026-04-23` + backfilled entries for #74/#75/#77 (were missing).

## Why 0.9.2 and not 0.10.0

No new public API surface; the Node 22.11 floor is already live from 0.9.1's `>=22`. 0.9.2 is consistent with the patch cadence used on the sibling repos for similarly-shaped work.

## Test plan

- [x] `npm test` — 138 passing
- [x] `npm run format:check` — clean
- [ ] CI green on the PR
- [ ] After merge: tag `v0.9.2` on `main` → `.github/workflows/release.yml` publishes to npm, generates signed SBOMs, and creates the GitHub Release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.9.2

* **Bug Fixes**
  * Fixed regex handling issues
  * Improved CI test result upload reliability
  * Enhanced coverage tracking compatibility

* **Added**
  * New ownership declaration support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->