### PR TITLE
chore(deps): bump Node floor to >=22.22 (22.22.2 CVEs)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     # Keep @types/node pinned on the 22.x line so its type surface
-    # tracks engines.node (>=22.11). A semver-major bump would declare
+    # tracks engines.node (>=22.22). A semver-major bump would declare
     # APIs the runtime doesn't guarantee. Reopen only when we move the
     # engines floor to a newer LTS.
     ignore:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Node.js floor bumped to `>=22.22`** (was `>=22.11`). Node 22.22.2 ships security fixes for seven CVEs, including two high-severity ones (TLS/SNI callback handling and HTTP header validation). The 22.22.x line is the current in-maintenance LTS patch train; pinning the floor there gives users a known-patched runtime instead of the pre-CVE 22.11 baseline. Aligned with the sibling repos `klodr/gmail-mcp`, `klodr/faxdrop-mcp`, and the private `klodr/relayfi-mcp`, all moving to `>=22.22` in the same pass. Also updates `README.md` comparison-table row, `SECURITY.md` "Supported runtimes", `llms-install.md` prerequisite, and `.github/dependabot.yml` `@types/node` major-clamp comment to the new floor.
+
 ### Fixed
 
 - **Audit throws no longer mask handler errors** (Qodo finding backported from `klodr/gmail-mcp#48`). A `logAudit(...)` call in the `finally` or `catch` would override the handler's own exception per JS/TS semantics — so a full-disk or a circular-`args` `JSON.stringify` throw inside the audit helper could erase the root cause from the caller. Introduces a local `safeLogAudit` wrapper that swallows any audit-side exception to stderr and applies it to all five terminal audit-log calls (rate-limit catch → `"error"`, `"dry-run"` early-return, `"ok"` success path, `"error"` catch before the `MercuryError` mapping, and the new `"error"` before a non-`RateLimitError` re-throw — previously missing, see next bullet). The runtime audit-`result` values on mercury are `"ok" | "dry-run" | "error"` (gmail also has a `"rate_limited"` state, mercury doesn't).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A Model Context Protocol (MCP) server giving AI assistants (Claude, Cursor, Cont
 | Built-in safeguards (rate limit, dry-run, redacted audit log) | ❌ | ❌ | ✅ |
 | Hosted (no token to manage) | ✅ | ❌ | ❌ |
 | Open source (MIT) | ❌ | ✅ | ✅ |
-| Node.js floor | N/A (hosted) | ❌ from Node 14 EOL (2023) | ✅ Active LTS (`>=22.11`) |
+| Node.js floor | N/A (hosted) | ❌ from Node 14 EOL (2023) | ✅ Active LTS (`>=22.22`) |
 | Total tools exposed | ~10 | ~11 | **34** |
 
 For pure read-only consultation, prefer the [official Mercury MCP](https://docs.mercury.com/docs/what-is-mercury-mcp). Use this one when you need to **automate invoicing, write to Mercury, or expose Mercury to LLM agents safely**.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -102,7 +102,7 @@ maintainer commits to, and limits that callers must account for.
 
 ## Supported runtimes
 
-`mercury-invoicing-mcp` supports **Node.js ≥ 22.11** (the LTS-tagged entry point of the Node 22 "Jod" line, October 2024; in Maintenance LTS through 2027-04-30). Releases prior to 0.9.1 shipped with a `>=20.11` floor; releases cut from 2026-04-30 onward require Node 22.11+ because Node 20 reaches end-of-life on 2026-04-30 and the `>=22.11` floor skips the pre-LTS 22.0–22.10 releases that predate the LTS designation. Older pinned versions of the package remain installable but will not receive back-ported security fixes.
+`mercury-invoicing-mcp` supports **Node.js ≥ 22.22** (the current Maintenance LTS patch train for the Node 22 "Jod" line, in maintenance through 2027-04-30). Releases prior to 0.9.1 shipped with `>=20.11`, then `>=22.11`; releases cut from 2026-04-23 onward require Node ≥ 22.22 so users pick up the seven CVEs addressed in the 22.22.x security release (two high-severity: TLS/SNI callback handling and HTTP header validation; three medium, two low). Older pinned versions of the package remain installable but will not receive back-ported security fixes.
 
 ## Verifying releases
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -7,7 +7,7 @@ client that can launch a stdio child process can use this server.
 
 ## Prerequisites the assistant should verify
 
-1. **Node.js ≥ 22.11** is installed (`node --version`).
+1. **Node.js ≥ 22.22** is installed (`node --version`).
 2. **npx** is on `PATH` (ships with Node).
 3. The user has — or is willing to create — a **Mercury API token** at
    <https://app.mercury.com/settings/tokens>. Tokens look like

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prepublishOnly": "NODE_ENV=production npm run build"
   },
   "engines": {
-    "node": ">=22.11"
+    "node": ">=22.22"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary
- Bump `engines.node` from `>=22.11` to `>=22.22` across the klodr/* MCP family so users pick up the seven CVEs addressed in Node 22.22.2 (two high-severity: TLS/SNI callback + HTTP header validation).
- Aligns sibling repos `klodr/gmail-mcp`, `klodr/faxdrop-mcp`, `klodr/mercury-invoicing-mcp`, and the private `klodr/relayfi-mcp` on the same floor.
- Updates the prose that references the old floor: `SECURITY.md`, `llms-install.md`, `.github/dependabot.yml` (`@types/node` major-clamp comment), and (mercury only) `README.md` comparison-table row.

## Test plan
- [ ] `engines.node` change visible in `package.json`
- [ ] CI matrix (Node 22 + 24) still green — `22` resolves to 22.22+ at action runtime
- [ ] No runtime API change (no ES2025 APIs introduced)

Refs: https://github.com/nodejs/node/releases/tag/v22.22.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Node.js version from `>=22.11` to `>=22.22` in package manifest and Dependabot configuration.

* **Documentation**
  * Updated README, installation guides, security policy, changelog, and configuration documentation to reflect the new Node.js `>=22.22` minimum version requirement across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->