### PR TITLE
chore(deps): pin Node floor to exact >=22.22.2 (CVE fixes)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     # Keep @types/node pinned on the 22.x line so its type surface
-    # tracks engines.node (>=22.22). A semver-major bump would declare
+    # tracks engines.node (>=22.22.2). A semver-major bump would declare
     # APIs the runtime doesn't guarantee. Reopen only when we move the
     # engines floor to a newer LTS.
     ignore:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Node.js floor bumped to `>=22.22`** (was `>=22.11`). Node 22.22.2 ships security fixes for seven CVEs, including two high-severity ones (TLS/SNI callback handling and HTTP header validation). The 22.22.x line is the current in-maintenance LTS patch train; pinning the floor there gives users a known-patched runtime instead of the pre-CVE 22.11 baseline. Aligned with the sibling repos `klodr/gmail-mcp`, `klodr/faxdrop-mcp`, and the private `klodr/relayfi-mcp`, all moving to `>=22.22` in the same pass. Also updates `README.md` comparison-table row, `SECURITY.md` "Supported runtimes", `llms-install.md` prerequisite, and `.github/dependabot.yml` `@types/node` major-clamp comment to the new floor.
+- **Node.js floor pinned to exact `>=22.22.2`** (was `>=22.22`, originally `>=22.11`). The previous `>=22.22` range accepted `22.22.0` and `22.22.1`, which predate the seven CVEs fixed in `22.22.2` (two high-severity: TLS/SNI callback handling and HTTP header validation; three medium, two low). Pinning to the exact patch closes the gap so a fresh `npm install` cannot land on a pre-CVE runtime. Aligned with `klodr/gmail-mcp`, `klodr/faxdrop-mcp` (shipped in PR #71), and the private `klodr/relayfi-mcp`. Also updates `README.md` comparison-table row, `SECURITY.md` "Supported runtimes", `llms-install.md` prerequisite, and `.github/dependabot.yml` `@types/node` major-clamp comment.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A Model Context Protocol (MCP) server giving AI assistants (Claude, Cursor, Cont
 | Built-in safeguards (rate limit, dry-run, redacted audit log) | ❌ | ❌ | ✅ |
 | Hosted (no token to manage) | ✅ | ❌ | ❌ |
 | Open source (MIT) | ❌ | ✅ | ✅ |
-| Node.js floor | N/A (hosted) | ❌ from Node 14 EOL (2023) | ✅ Active LTS (`>=22.22`) |
+| Node.js floor | N/A (hosted) | ❌ from Node 14 EOL (2023) | ✅ Active LTS (`>=22.22.2`) |
 | Total tools exposed | ~10 | ~11 | **34** |
 
 For pure read-only consultation, prefer the [official Mercury MCP](https://docs.mercury.com/docs/what-is-mercury-mcp). Use this one when you need to **automate invoicing, write to Mercury, or expose Mercury to LLM agents safely**.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -102,7 +102,7 @@ maintainer commits to, and limits that callers must account for.
 
 ## Supported runtimes
 
-`mercury-invoicing-mcp` supports **Node.js ≥ 22.22** (the current Maintenance LTS patch train for the Node 22 "Jod" line, in maintenance through 2027-04-30). Releases prior to 0.9.1 shipped with `>=20.11`, then `>=22.11`; releases cut from 2026-04-23 onward require Node ≥ 22.22 so users pick up the seven CVEs addressed in the 22.22.x security release (two high-severity: TLS/SNI callback handling and HTTP header validation; three medium, two low). Older pinned versions of the package remain installable but will not receive back-ported security fixes.
+`mercury-invoicing-mcp` supports **Node.js ≥ 22.22.2** (the patched release on the Node 22 "Jod" Maintenance LTS, in maintenance through 2027-04-30). The floor is pinned to the exact patch — not just `22.22.x` — because the seven CVEs landed in `22.22.2` specifically (two high-severity: TLS/SNI callback handling and HTTP header validation; three medium, two low); `22.22.0` and `22.22.1` predate those fixes. Releases prior to 0.9.1 shipped with `>=20.11`, then `>=22.11`. Older pinned versions of the package remain installable but will not receive back-ported security fixes.
 
 ## Verifying releases
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -7,7 +7,7 @@ client that can launch a stdio child process can use this server.
 
 ## Prerequisites the assistant should verify
 
-1. **Node.js ≥ 22.22** is installed (`node --version`).
+1. **Node.js ≥ 22.22.2** is installed (`node --version`).
 2. **npx** is on `PATH` (ships with Node).
 3. The user has — or is willing to create — a **Mercury API token** at
    <https://app.mercury.com/settings/tokens>. Tokens look like

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prepublishOnly": "NODE_ENV=production npm run build"
   },
   "engines": {
-    "node": ">=22.22"
+    "node": ">=22.22.2"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary
Follow-up to the previous `>=22.22` bump. Pins the Node floor to the exact patch `>=22.22.2` so a fresh `npm install` cannot land on `22.22.0` / `22.22.1`, which predate the seven CVEs addressed in `22.22.2` (two high-severity: TLS/SNI callback + HTTP header validation).

Aligns with sibling `klodr/faxdrop-mcp` (already shipped in #71) and `klodr/relayfi-mcp` (main).

## Test plan
- [ ] `engines.node` reflects the pinned patch
- [ ] CI still green on Node 22 + 24
- [ ] No runtime API change

Refs: https://github.com/nodejs/node/releases/tag/v22.22.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js minimum version requirement to 22.22.2 (previously 22.22) across package configuration and documentation, including README, security policy, and installation guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->