### PR TITLE
chore: align config files (eslint header, eqeqeq style, tsup sourcemap)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,4 @@
-// ESLint v9 flat config.
+// ESLint v10 flat config.
 // Type-aware rules: requires `parserOptions.projectService: true` (TS 5+).
 
 import js from "@eslint/js";
@@ -31,7 +31,7 @@ export default tseslint.config(
     },
     rules: {
       // High-value additions over `recommendedTypeChecked`:
-      "eqeqeq": ["error", "always"],
+      eqeqeq: ["error", "always"],
       "no-console": ["warn", { allow: ["error", "warn"] }],
       // The recommendedTypeChecked preset already enables:
       // - @typescript-eslint/no-floating-promises

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,10 +5,12 @@ export default defineConfig({
   format: ["esm"],
   target: "node22",
   dts: false,
-  // Sourcemaps in dev (npm run dev / npm test); never in published artifacts
-  // because they would expose the full TS source under dist/index.js.map.
-  sourcemap: process.env.NODE_ENV !== "production",
+  // Sourcemaps are opt-in only (MERCURY_MCP_SOURCEMAP=true). Every other
+  // invocation — including local `npm publish`, `npm run build`, CI, and
+  // the release workflow — produces a map-less bundle, so a forgotten
+  // NODE_ENV cannot accidentally ship TS sources under dist/index.js.map.
+  sourcemap: process.env.MERCURY_MCP_SOURCEMAP === "true",
   clean: true,
   shims: true,
-  banner: { js: "#!/usr/bin/env node" }
+  banner: { js: "#!/usr/bin/env node" },
 });


### PR DESCRIPTION
## Summary

Three small drift items spotted in a cross-repo config audit (gmail-mcp, faxdrop-mcp, mercury-invoicing-mcp).

### `eslint.config.js`
- Header: `// ESLint v9 flat config.` was stale — `package.json` declares ESLint v10. Updated.
- `"eqeqeq": ["error", "always"]` was the only quoted key in the rules block. Unquoted to match surrounding style + sibling repos.

### `tsup.config.ts`
Tightened sourcemap policy: was `NODE_ENV !== "production"` (default ON unless prod). Now opt-in via `MERCURY_MCP_SOURCEMAP=true`, mirroring the strict `klodr/gmail-mcp` policy. Closes the leak path where a forgotten `NODE_ENV` ships `dist/index.js.map` to npm.

To debug locally: `MERCURY_MCP_SOURCEMAP=true npm run build`.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm test` (183/183 passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint configuration version reference
  * Modified build configuration for sourcemap generation based on environment settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->