### PR TITLE
chore(release): v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-04-25
+
 ### Added
 
 - **Community-health files** — `.github/SUPPORT.md` (issue-redirection page surfaced by GitHub on issue creation, with best-effort response SLOs) and `CITATION.cff` (Citation File Format metadata enabling the GitHub "Cite this repository" button on the repo page).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -500,3 +500,31 @@ This release supersedes **all** prior 0.x versions of `mercury-invoicing-mcp`. T
 - npm publish workflow with provenance attestation
 - Smithery + Official MCP Registry manifests
 - Examples and publishing checklist
+
+[Unreleased]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.9.2...v0.10.0
+[0.9.2]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.9.1...v0.9.2
+[0.9.1]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.9.0...v0.9.1
+[0.9.0]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.8.6...v0.9.0
+[0.8.6]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.8.5...v0.8.6
+[0.8.5]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.8.4...v0.8.5
+[0.8.4]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.8.2...v0.8.4
+[0.8.2]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.8.1...v0.8.2
+[0.8.1]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.8.0...v0.8.1
+[0.8.0]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.7.9...v0.8.0
+[0.7.9]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.7.8...v0.7.9
+[0.7.8]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.7.7...v0.7.8
+[0.7.7]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.7.6...v0.7.7
+[0.7.6]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.7.5...v0.7.6
+[0.7.5]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.7.4...v0.7.5
+[0.7.4]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.7.3...v0.7.4
+[0.7.3]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.7.2...v0.7.3
+[0.7.2]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.7.1...v0.7.2
+[0.7.1]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.6.2...v0.7.0
+[0.6.2]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.2.0...v0.6.0
+[0.2.0]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/klodr/mercury-invoicing-mcp/releases/tag/v0.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@ import { registerAllPrompts } from "./prompts/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.10.0";
+export const VERSION = "0.11.0";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 export interface ServerOptions {


### PR DESCRIPTION
## Summary

Cuts v0.11.0 from main. Minor version bump — adds community-health surface (SUPPORT.md, CITATION.cff, FUNDING-via-package.json), reorganizes the repo root, tightens supply-chain posture, aligns config files with sibling klodr/* repos.

## Highlights

### Added
- `.github/SUPPORT.md` — issue-redirection page surfaced by GitHub on issue creation. Spells out the JSONL audit-log shape (`ts`, `tool`, `result`, `args`), the middleware-redacted set (token, email/phone, account/routing numbers, amount, webhook secrets), and the reporter-redacted set.
- `CITATION.cff` — enables the GitHub "Cite this repository" button.
- `package.json` `funding` field → GitHub Sponsors button on `npmjs.com`.
- `CHANGELOG.md` added to `package.json` `files` allowlist.
- `.github/social-preview.png` — GitHub Open Graph image (1280×640).

### Changed
- **Stricter Socket Security posture** — `socket.yml` no longer silences `unstableOwnership` / `unmaintained` / `manifestConfusion`. Now alerts on transitive owner changes / abandonware / manifest mismatch.
- **Stricter sourcemap policy** — `tsup.config.ts` opt-in via `MERCURY_MCP_SOURCEMAP=true`. Closes leak path where forgotten `NODE_ENV` ships `dist/index.js.map`.
- **Config drift fixed** — `eslint.config.js` header v9 → v10 (factual), `eqeqeq` style aligned.
- **Repository structure cleanup** — community-health files moved to `.github/`, general docs to `docs/`. Internal links updated.
- **README "Why this MCP?" comparison row reworded** — `Hosted (no token to manage) ✅ ❌ ❌` → `Stable token (no frequent re-auth, IP-allowlistable) ❌ ✅ ✅`. Hosted MCPs require frequent OAuth re-auth in practice; stable token + IP-allowlist is the operational option.

## Release plan

After merge:
1. `git tag -s v0.11.0 && git push origin v0.11.0`
2. The `release.yml` workflow publishes to npm with Sigstore + SLSA + npm provenance.
3. `verify-release.yml` re-exercises the three verification paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped release to 0.11.0 across package metadata, server manifest and server version references.
  * Updated changelog to add a 0.11.0 release section (dated 2026-04-25) and refreshed reference-style compare links for Unreleased, 0.11.0, and prior tagged versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->