### PR TITLE
docs(readme): drop redundant MIT license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 [![npm version](https://img.shields.io/npm/v/mercury-invoicing-mcp.svg)](https://www.npmjs.com/package/mercury-invoicing-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/mercury-invoicing-mcp.svg)](https://www.npmjs.com/package/mercury-invoicing-mcp)
 [![Node.js Version](https://img.shields.io/node/v/mercury-invoicing-mcp.svg)](https://nodejs.org)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![MCP](https://img.shields.io/badge/MCP-1.29-blue)](https://modelcontextprotocol.io)
 [![MCP Server](https://badge.mcpx.dev?type=server 'MCP Server')](https://modelcontextprotocol.io)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/klodr/mercury-invoicing-mcp/pulls)


### PR DESCRIPTION
## Summary
Drop the `[![License: MIT]…]` badge from the README header.

The MIT license is already surfaced in two more authoritative places:
- **GitHub sidebar** (auto-detected from `LICENSE` file)
- **npm package page** (right rail, parsed from the `license` field of `package.json`)

Keeping a third copy in the README adds noise without information. Discoverability of the license is unchanged.

## Test plan
- [x] No code change, README still renders cleanly
- [x] `LICENSE` file untouched
- [x] `package.json` `license` field untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed MIT license badge from README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->