### PR TITLE
fix(server): validate MERCURY_API_BASE_URL override (SSRF defense)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "ipaddr.js": "^2.3.0",
         "us-bank-account-validator": "^1.1.0",
         "zod": "^4.3.6"
       },
@@ -30,7 +31,10 @@
         "vitest": "^4.1.4"
       },
       "engines": {
-        "node": ">=22.11"
+        "node": ">=22.22.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/klodr"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -3195,12 +3199,12 @@
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
+      "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10"
       }
     },
     "node_modules/is-extglob": {
@@ -4153,6 +4157,15 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "packageManager": "npm@10.9.7",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "ipaddr.js": "^2.3.0",
     "us-bank-account-validator": "^1.1.0",
     "zod": "^4.3.6"
   },

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,6 +3,8 @@
  * Docs: https://docs.mercury.com/reference/getting-started-with-your-api
  */
 
+import { assertSafeUrl } from "./safe-url.js";
+
 const BASE_URL = "https://api.mercury.com/api/v1";
 
 export interface MercuryClientOptions {
@@ -65,11 +67,21 @@ export class MercuryClient {
     };
     if (init.body !== undefined) headers["Content-Type"] = "application/json";
 
+    // Runtime SSRF defense: re-resolve the URL hostname and reject if any
+    // record points at a non-`unicast` range. Combined with the boot-time
+    // `validateBaseUrl()` check this closes DNS-rebinding + redirect-into-
+    // private-host gaps without migrating off the native fetch API.
+    await assertSafeUrl(url);
+
     const res = await fetch(url, {
       method,
       headers,
       body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
       signal: AbortSignal.timeout(30_000),
+      // `redirect: "manual"` would let us re-classify each Location hop,
+      // but Mercury's API does not redirect — keep `follow` (default) and
+      // rely on the boot + assertSafeUrl coverage. If a future endpoint
+      // ever sends a 30x, the response status surfaces it.
     });
 
     const text = await res.text();

--- a/src/client.ts
+++ b/src/client.ts
@@ -106,11 +106,22 @@ export class MercuryClient {
       headers,
       body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
       signal: AbortSignal.timeout(30_000),
-      // `redirect: "manual"` would let us re-classify each Location hop,
-      // but Mercury's API does not redirect — keep `follow` (default) and
-      // rely on the boot + assertSafeUrl coverage. If a future endpoint
-      // ever sends a 30x, the response status surfaces it.
+      // Fail closed on any 30x. The default `redirect: "follow"` would
+      // let undici chase a Location header transparently — bouncing the
+      // bearer token to whatever host the redirect points at, which
+      // `assertSafeUrl()` never re-classifies because the redirect is
+      // handled below the public fetch surface. Mercury's API does not
+      // redirect today; if it ever does, the explicit throw below
+      // catches it instead of leaking the token.
+      redirect: "manual",
     });
+
+    if (res.status >= 300 && res.status < 400) {
+      throw new MercuryError(
+        `Mercury API ${method} ${path} returned an unexpected redirect (HTTP ${res.status}); refusing to follow to avoid SSRF / token leak.`,
+        res.status,
+      );
+    }
 
     const text = await res.text();
     let json: unknown;

--- a/src/safe-url.ts
+++ b/src/safe-url.ts
@@ -64,9 +64,14 @@ export async function assertSafeUrl(rawUrl: string | URL): Promise<void> {
   // DNS hostname — resolve every record and classify each one.
   const records = await lookup(host, { all: true });
   for (const r of records) {
+    /* v8 ignore next -- node:dns guarantees `r.address` is a valid IP literal,
+       so this guard is purely defensive against a future Node behaviour change. */
     if (!ipaddr.isValid(r.address)) continue;
     const range = ipaddr.process(r.address).range();
     if (range !== "unicast") {
+      /* v8 ignore next -- exercised only when DNS resolves a hostname to a
+         non-unicast IP. Deterministic coverage would need a stub DNS server,
+         not worth the maintenance for a defense-in-depth runtime gate. */
       throw new Error(`Refusing to fetch ${host}: DNS resolved to ${r.address} (range "${range}")`);
     }
   }

--- a/src/safe-url.ts
+++ b/src/safe-url.ts
@@ -1,0 +1,73 @@
+import { lookup } from "node:dns/promises";
+import ipaddr from "ipaddr.js";
+
+/**
+ * Runtime SSRF defense: before each outbound HTTP call, resolve the URL's
+ * hostname and reject if any of its A/AAAA records points at a non-`unicast`
+ * range (loopback, RFC 1918, RFC 3927 link-local, RFC 6598 carrier-grade
+ * NAT, RFC 2544 benchmarking, RFC 5737 documentation, multicast, IPv6 ULA,
+ * IPv6 link-local, etc.).
+ *
+ * Why this exists in addition to `validateBaseUrl()`:
+ *
+ *   `validateBaseUrl()` runs once at startup against the URL string. It
+ *   does not protect against:
+ *     - DNS rebinding (DNS resolves to public at boot, private later).
+ *     - HTTP redirect chains that land on a private host.
+ *     - URL changes mid-process.
+ *
+ *   `assertSafeUrl()` runs before every fetch and re-classifies the
+ *   resolved IPs. Combined with `validateBaseUrl()` at boot, this is the
+ *   same defense layer as `request-filtering-agent`-style request gating
+ *   while keeping the native Node `fetch` API (no `node-fetch` migration).
+ *
+ *   Residual: tiny TOCTOU window between this lookup and the actual TCP
+ *   connect — DNS could rebind in milliseconds. That window is documented
+ *   in `.github/SECURITY.md`; closing it would require socket-level
+ *   interception (custom undici dispatcher, future work).
+ */
+export async function assertSafeUrl(rawUrl: string | URL): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = typeof rawUrl === "string" ? new URL(rawUrl) : rawUrl;
+  } catch {
+    throw new Error(`Refusing to fetch invalid URL: ${String(rawUrl)}`);
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error(
+      `Refusing to fetch ${parsed.protocol}// URL — bearer token would leak in clear`,
+    );
+  }
+
+  const rawHost = parsed.hostname.toLowerCase();
+  const host = rawHost.startsWith("[") && rawHost.endsWith("]") ? rawHost.slice(1, -1) : rawHost;
+
+  // RFC 6761 .localhost namespace — reject before any DNS lookup.
+  if (
+    host === "localhost" ||
+    host === "localhost." ||
+    host.endsWith(".localhost") ||
+    host.endsWith(".localhost.")
+  ) {
+    throw new Error(`Refusing to fetch RFC 6761 loopback host: ${host}`);
+  }
+
+  // IP literal — classify directly via ipaddr.js, skip DNS.
+  if (ipaddr.isValid(host)) {
+    const range = ipaddr.process(host).range();
+    if (range !== "unicast") {
+      throw new Error(`Refusing to fetch IP literal ${host} (range "${range}")`);
+    }
+    return;
+  }
+
+  // DNS hostname — resolve every record and classify each one.
+  const records = await lookup(host, { all: true });
+  for (const r of records) {
+    if (!ipaddr.isValid(r.address)) continue;
+    const range = ipaddr.process(r.address).range();
+    if (range !== "unicast") {
+      throw new Error(`Refusing to fetch ${host}: DNS resolved to ${r.address} (range "${range}")`);
+    }
+  }
+}

--- a/src/safe-url.ts
+++ b/src/safe-url.ts
@@ -64,14 +64,9 @@ export async function assertSafeUrl(rawUrl: string | URL): Promise<void> {
   // DNS hostname — resolve every record and classify each one.
   const records = await lookup(host, { all: true });
   for (const r of records) {
-    /* v8 ignore next -- node:dns guarantees `r.address` is a valid IP literal,
-       so this guard is purely defensive against a future Node behaviour change. */
     if (!ipaddr.isValid(r.address)) continue;
     const range = ipaddr.process(r.address).range();
     if (range !== "unicast") {
-      /* v8 ignore next -- exercised only when DNS resolves a hostname to a
-         non-unicast IP. Deterministic coverage would need a stub DNS server,
-         not worth the maintenance for a defense-in-depth runtime gate. */
       throw new Error(`Refusing to fetch ${host}: DNS resolved to ${r.address} (range "${range}")`);
     }
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -126,8 +126,11 @@ export function validateBaseUrl(raw: string): void {
   }
   const ipv4MappedHex = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
   if (ipv4MappedHex) {
+    // Only the high 16 bits decide the private-range outcome — the
+    // `isPrivateIPv4` predicate inspects octets a + b, none of c + d.
+    // Skip parsing the low pair to avoid an unused-variable lint flag
+    // (caught by CodeRabbit on the IPv6 follow-up commit).
     const high = Number.parseInt(ipv4MappedHex[1], 16);
-    const low = Number.parseInt(ipv4MappedHex[2], 16);
     const a = (high >> 8) & 0xff;
     const b = high & 0xff;
     if (isPrivateIPv4({ a, b })) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,11 @@ import { registerAllPrompts } from "./prompts/index.js";
 export const VERSION = "0.12.0";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
+// Strict allowlist of Mercury hostnames `validateBaseUrl()` accepts without
+// the explicit `MERCURY_MCP_ALLOW_NON_MERCURY_HOST=true` opt-in. New entries
+// require explicit code review (no wildcard).
+export const MERCURY_HOSTS = ["api.mercury.com", "api-sandbox.mercury.com"] as const;
+
 export interface ServerOptions {
   apiKey: string;
   /** Override the Mercury API base URL (e.g. for a self-hosted proxy). */
@@ -123,8 +128,7 @@ export function validateBaseUrl(raw: string): void {
   // Legitimate self-hosted proxies / observability shims opt in via
   // `MERCURY_MCP_ALLOW_NON_MERCURY_HOST=true`, which surfaces a loud
   // stderr warning so the deviation is visible at boot.
-  const MERCURY_HOSTS = ["api.mercury.com", "api-sandbox.mercury.com"];
-  const isMercuryHost = MERCURY_HOSTS.includes(host);
+  const isMercuryHost = (MERCURY_HOSTS as readonly string[]).includes(host);
   if (!isMercuryHost) {
     if (process.env.MERCURY_MCP_ALLOW_NON_MERCURY_HOST !== "true") {
       throw new Error(

--- a/src/server.ts
+++ b/src/server.ts
@@ -110,9 +110,30 @@ export function validateBaseUrl(raw: string): void {
       );
     }
   }
-  // Hostnames that don't parse as an IP literal are treated as DNS — accepted
-  // here. The Mercury client will reject them at request time if they don't
-  // resolve to a usable target.
+
+  // Default-allow only the official Mercury hostnames. The previous rules
+  // (HTTPS-only + non-public-range gate) keep an attacker-controlled env
+  // var like `MERCURY_API_BASE_URL=https://attacker.example.com` from
+  // pointing at a private host, but they still let it route the bearer
+  // token to *any* public host. Lock to `api.mercury.com` and
+  // `api-sandbox.mercury.com` by default; legitimate self-hosted
+  // proxies / observability shims have to opt in explicitly via
+  // `MERCURY_MCP_ALLOW_NON_MERCURY_HOST=true`, which surfaces a loud
+  // stderr warning so the deviation is visible at boot.
+  const isMercuryHost =
+    host === "api.mercury.com" ||
+    host === "api-sandbox.mercury.com" ||
+    host.endsWith(".mercury.com");
+  if (!isMercuryHost) {
+    if (process.env.MERCURY_MCP_ALLOW_NON_MERCURY_HOST !== "true") {
+      throw new Error(
+        `MERCURY_API_BASE_URL=${host} is not a Mercury hostname. Set MERCURY_MCP_ALLOW_NON_MERCURY_HOST=true to opt in to a custom proxy / observability shim — be aware the bearer token + every API payload will be sent to that host.`,
+      );
+    }
+    console.error(
+      `[validateBaseUrl] WARNING: MERCURY_API_BASE_URL points at a non-Mercury host (${host}). Bearer token + every API payload will be sent there. Opted in via MERCURY_MCP_ALLOW_NON_MERCURY_HOST=true.`,
+    );
+  }
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -111,19 +111,20 @@ export function validateBaseUrl(raw: string): void {
     }
   }
 
-  // Default-allow only the official Mercury hostnames. The previous rules
-  // (HTTPS-only + non-public-range gate) keep an attacker-controlled env
-  // var like `MERCURY_API_BASE_URL=https://attacker.example.com` from
-  // pointing at a private host, but they still let it route the bearer
-  // token to *any* public host. Lock to `api.mercury.com` and
-  // `api-sandbox.mercury.com` by default; legitimate self-hosted
-  // proxies / observability shims have to opt in explicitly via
+  // Default-allow only the two official Mercury API hostnames. The
+  // previous rules (HTTPS-only + non-public-range gate) keep an
+  // attacker-controlled env var like
+  // `MERCURY_API_BASE_URL=https://attacker.example.com` from pointing
+  // at a private host, but they still let it route the bearer token
+  // to *any* public host. Lock the allowlist to the exact strings
+  // Mercury actually exposes — no `*.mercury.com` wildcard, because
+  // any subdomain Mercury adds in the future would also need code
+  // review before it inherits write access to the bearer token.
+  // Legitimate self-hosted proxies / observability shims opt in via
   // `MERCURY_MCP_ALLOW_NON_MERCURY_HOST=true`, which surfaces a loud
   // stderr warning so the deviation is visible at boot.
-  const isMercuryHost =
-    host === "api.mercury.com" ||
-    host === "api-sandbox.mercury.com" ||
-    host.endsWith(".mercury.com");
+  const MERCURY_HOSTS = ["api.mercury.com", "api-sandbox.mercury.com"];
+  const isMercuryHost = MERCURY_HOSTS.includes(host);
   if (!isMercuryHost) {
     if (process.env.MERCURY_MCP_ALLOW_NON_MERCURY_HOST !== "true") {
       throw new Error(

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,11 +18,100 @@ export interface ServerOptions {
 }
 
 /**
+ * Validate an explicit `MERCURY_API_BASE_URL` override before it is forwarded
+ * to the Mercury client.
+ *
+ * Defense-in-depth layer. The bearer token + every API call is sent to this
+ * URL. Without validation, an operator misconfiguration (or a host that lets
+ * prompt-injected content reach env composition) could redirect traffic to
+ * `http://attacker.tld` and silently exfiltrate credentials.
+ *
+ * Rules mirror `HttpsWebhookUrl` in `src/tools/webhooks.ts` for symmetry:
+ *
+ *   - HTTPS required: a plaintext or non-HTTP scheme would leak the bearer
+ *     token + every payload in clear. The official Mercury API + sandbox are
+ *     both HTTPS, so this rule costs the legitimate caller nothing.
+ *   - Loopback / RFC 1918 / link-local / cloud-metadata / IPv6 ULA blocked:
+ *     guards against accidental misconfiguration (e.g. a base URL pointing at
+ *     `https://169.254.169.254/latest/meta-data` or a private corporate IP)
+ *     and against prompt injections that try to bounce through an internal
+ *     service. Mercury's own API is on a public hostname, so this rule costs
+ *     the legitimate caller nothing.
+ *
+ * Throws on invalid input. The thrown message is logged at boot and never
+ * leaked to the LLM channel.
+ */
+export function validateBaseUrl(raw: string): void {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(
+      `MERCURY_API_BASE_URL is not a valid URL (got ${JSON.stringify(raw)}). Expected an HTTPS URL such as https://api.mercury.com/api/v1.`,
+    );
+  }
+
+  if (url.protocol !== "https:") {
+    throw new Error(
+      `MERCURY_API_BASE_URL must use https:// (got ${JSON.stringify(url.protocol)}). http, file, data, ftp, etc. are rejected to prevent bearer-token leakage.`,
+    );
+  }
+
+  // Unwrap bracketed IPv6 literals — `URL().hostname` keeps the brackets for
+  // IPv6 ([::1], [fe80::1]) — strip before range checks.
+  const rawHost = url.hostname.toLowerCase();
+  const host = rawHost.startsWith("[") && rawHost.endsWith("]") ? rawHost.slice(1, -1) : rawHost;
+
+  if (host === "localhost" || host === "::1") {
+    throw new Error(
+      "MERCURY_API_BASE_URL must be publicly reachable. Loopback hosts are rejected.",
+    );
+  }
+
+  // IPv4: match literal a.b.c.d and reject loopback, link-local, RFC 1918.
+  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4) {
+    const a = Number(ipv4[1]);
+    const b = Number(ipv4[2]);
+    if (
+      a === 0 || //                              0.0.0.0/8      "this host"/unspecified
+      a === 127 || //                            127.0.0.0/8    loopback
+      a === 10 || //                             10.0.0.0/8     RFC 1918
+      (a === 169 && b === 254) || //             169.254.0.0/16 link-local + cloud metadata
+      (a === 192 && b === 168) || //             192.168.0.0/16 RFC 1918
+      (a === 172 && b >= 16 && b <= 31) //       172.16.0.0/12  RFC 1918
+    ) {
+      throw new Error(
+        `MERCURY_API_BASE_URL must be publicly reachable. Got ${host} which is loopback/RFC 1918/link-local/cloud-metadata.`,
+      );
+    }
+  }
+
+  // IPv6 CIDR bitmask check on the first hextet:
+  //   fc00::/7  → first 7 bits = 0b1111110 → mask 0xfe00, match 0xfc00 (ULA)
+  //   fe80::/10 → first 10 bits = 0b1111111010 → mask 0xffc0, match 0xfe80 (link-local)
+  const firstHextet = Number.parseInt(host.split(":")[0], 16);
+  if (!Number.isNaN(firstHextet)) {
+    if ((firstHextet & 0xfe00) === 0xfc00 || (firstHextet & 0xffc0) === 0xfe80) {
+      throw new Error(
+        `MERCURY_API_BASE_URL must be publicly reachable. Got ${host} which is in a private IPv6 range (fc00::/7 ULA or fe80::/10 link-local).`,
+      );
+    }
+  }
+}
+
+/**
  * Resolve the Mercury API base URL from the API key + an optional explicit
  * override. Sandbox tokens (containing "mercury_sandbox_") are auto-detected.
+ *
+ * Validates an explicit override via `validateBaseUrl` — see that function
+ * for the rule set.
  */
 export function resolveBaseUrl(apiKey: string, explicitBaseUrl?: string): string | undefined {
-  if (explicitBaseUrl) return explicitBaseUrl;
+  if (explicitBaseUrl) {
+    validateBaseUrl(explicitBaseUrl);
+    return explicitBaseUrl;
+  }
   // Strict prefix match so a token like "mercury_production_with_word_sandbox_in_it"
   // is not accidentally routed to sandbox.
   if (apiKey.startsWith("secret-token:mercury_sandbox_")) return SANDBOX_BASE_URL;

--- a/src/server.ts
+++ b/src/server.ts
@@ -96,8 +96,17 @@ export function validateBaseUrl(raw: string): void {
   if (ipaddr.isValid(host)) {
     const range = ipaddr.process(host).range();
     if (range !== "unicast") {
+      // Stable user-facing message — explicitly do NOT interpolate the
+      // raw `range` value from `ipaddr.js`. The library's classification
+      // taxonomy is an internal implementation detail; coupling the
+      // contract to those exact label strings would force a release
+      // every time upstream renames a label (uniqueLocal → ULA, etc.)
+      // and would force test fixtures to track those renames too.
+      // Log the raw range to stderr for debug-level diagnosis instead.
+      // (Caught by CodeRabbit on this PR.)
+      console.error(`[validateBaseUrl] rejected host=${host} ipaddr.js-range=${range}`);
       throw new Error(
-        `MERCURY_API_BASE_URL must be publicly reachable. Got ${host} which falls in the "${range}" range.`,
+        `MERCURY_API_BASE_URL must point at a publicly reachable IP — ${host} is in a non-public range (loopback / private / link-local / carrier-grade NAT / reserved / IPv6 ULA / ...).`,
       );
     }
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import ipaddr from "ipaddr.js";
 import { MercuryClient } from "./client.js";
 import { registerAllTools } from "./tools/index.js";
 import { registerAllPrompts } from "./prompts/index.js";
@@ -26,17 +27,19 @@ export interface ServerOptions {
  * prompt-injected content reach env composition) could redirect traffic to
  * `http://attacker.tld` and silently exfiltrate credentials.
  *
- * Rules mirror `HttpsWebhookUrl` in `src/tools/webhooks.ts` for symmetry:
+ * Rules:
  *
  *   - HTTPS required: a plaintext or non-HTTP scheme would leak the bearer
  *     token + every payload in clear. The official Mercury API + sandbox are
  *     both HTTPS, so this rule costs the legitimate caller nothing.
- *   - Loopback / RFC 1918 / link-local / cloud-metadata / IPv6 ULA blocked:
- *     guards against accidental misconfiguration (e.g. a base URL pointing at
- *     `https://169.254.169.254/latest/meta-data` or a private corporate IP)
- *     and against prompt injections that try to bounce through an internal
- *     service. Mercury's own API is on a public hostname, so this rule costs
- *     the legitimate caller nothing.
+ *   - RFC 6761 `.localhost` namespace blocked (covers `localhost`,
+ *     `localhost.`, `foo.localhost`, `foo.localhost.`). DNS-level loopback.
+ *   - IP-literal classification delegated to `ipaddr.js` — accept only the
+ *     `unicast` range. Everything else (loopback / private / linkLocal /
+ *     carrierGradeNat / benchmarking / documentation / multicast /
+ *     uniqueLocal / etc.) is rejected. This pulls in the IANA-tracked range
+ *     set so we do not have to maintain a hand-written CIDR list and do not
+ *     drift when IANA reserves new ranges.
  *
  * Throws on invalid input. The thrown message is logged at boot and never
  * leaked to the LLM channel.
@@ -58,23 +61,17 @@ export function validateBaseUrl(raw: string): void {
   }
 
   // `URL().hostname` returns IPv6 literals bracketed ([::1], [fe80::1]).
-  // DNS names and IPv4 dotted-quads come back unbracketed. The brackets
-  // are how we distinguish "this host is an IPv6 literal" from "this is
-  // a DNS name that happens to contain a hex prefix" — without that
-  // gate, a hostname like `fc00-proxy.example.com` would be wrongly
-  // rejected as ULA because `parseInt("fc00-proxy", 16)` returns 0xfc00.
-  // (Caught by CodeRabbit on this PR.)
+  // DNS names and IPv4 dotted-quads come back unbracketed. Brackets are
+  // also how we tell "this is an IPv6 literal" from "this is a DNS name
+  // that happens to contain a hex-shaped substring" — `fc00-proxy.example.com`
+  // is a perfectly valid DNS name and must pass.
   const rawHost = url.hostname.toLowerCase();
   const isIPv6Literal = rawHost.startsWith("[") && rawHost.endsWith("]");
   const host = isIPv6Literal ? rawHost.slice(1, -1) : rawHost;
 
-  // RFC 6761 reserves the entire `.localhost` namespace as loopback —
-  // not just the bare label. `localhost.`, `foo.localhost`, and
-  // `foo.localhost.` all resolve to a loopback target on stacks that
-  // honor the spec, so a bearer token sent to any of them leaks the
-  // same way as `https://127.0.0.1/`. Reject the namespace as a
-  // whole, before the non-IPv6 fast path. (Caught by CodeRabbit on
-  // this PR.)
+  // RFC 6761: the entire `.localhost` namespace resolves to a loopback
+  // target on conforming stacks. Reject it at the DNS level before any
+  // IP-literal classification.
   if (
     host === "localhost" ||
     host === "localhost." ||
@@ -86,85 +83,27 @@ export function validateBaseUrl(raw: string): void {
     );
   }
 
-  // IPv4: match literal a.b.c.d and reject loopback, link-local, RFC 1918.
-  const ipv4Match = (raw: string): null | { a: number; b: number } => {
-    const m = raw.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-    if (!m) return null;
-    return { a: Number(m[1]), b: Number(m[2]) };
-  };
-
-  const isPrivateIPv4 = ({ a, b }: { a: number; b: number }): boolean =>
-    a === 0 || //                              0.0.0.0/8      "this host"/unspecified
-    a === 127 || //                            127.0.0.0/8    loopback
-    a === 10 || //                             10.0.0.0/8     RFC 1918
-    (a === 169 && b === 254) || //             169.254.0.0/16 link-local + cloud metadata
-    (a === 192 && b === 168) || //             192.168.0.0/16 RFC 1918
-    (a === 172 && b >= 16 && b <= 31); //      172.16.0.0/12  RFC 1918
-
-  if (!isIPv6Literal) {
-    const ipv4 = ipv4Match(host);
-    if (ipv4 && isPrivateIPv4(ipv4)) {
+  // If the host parses as an IP literal, classify it via `ipaddr.js` and
+  // accept only the `unicast` range. The library covers every IANA-tracked
+  // reserved range — loopback (RFC 5735), private (RFC 1918), linkLocal
+  // (RFC 3927 + IPv6 fe80::/10), carrierGradeNat (RFC 6598),
+  // benchmarking (RFC 2544), documentation (RFC 5737 + RFC 3849), multicast,
+  // uniqueLocal (IPv6 fc00::/7), reserved, etc. — without us having to
+  // maintain a hand-rolled CIDR list. IPv4-mapped IPv6 (`::ffff:a.b.c.d`,
+  // `::ffff:7f00:1`) is normalised by ipaddr.js into the underlying IPv4
+  // range, so a mapped private address is rejected the same way as the
+  // bare IPv4 form.
+  if (ipaddr.isValid(host)) {
+    const range = ipaddr.process(host).range();
+    if (range !== "unicast") {
       throw new Error(
-        `MERCURY_API_BASE_URL must be publicly reachable. Got ${host} which is loopback/RFC 1918/link-local/cloud-metadata.`,
-      );
-    }
-    return; // DNS names that aren't loopback / IPv4-private get a pass.
-  }
-
-  // From here, `host` is an IPv6 literal (brackets stripped).
-
-  // Loopback in any form: ::1, 0:0:0:0:0:0:0:1, etc.
-  // Easy invariant: collapse runs of zero hextets and check for `::1` or `0::1`.
-  const collapsedZeros = host.replace(/(?:^|:)(?:0+:)+/g, "::").replace(/::+/g, "::");
-  if (collapsedZeros === "::1" || collapsedZeros === "0::1") {
-    throw new Error(
-      "MERCURY_API_BASE_URL must be publicly reachable. Loopback hosts are rejected.",
-    );
-  }
-
-  // IPv4-mapped IPv6: re-run the IPv4 private-range check on the embedded
-  // address, otherwise `[::ffff:127.0.0.1]` would slip past. Two shapes:
-  //   - dotted-quad: `::ffff:127.0.0.1` (untouched by some parsers)
-  //   - hex pair: `::ffff:7f00:1` (Node's `URL().hostname` canonicalises to this)
-  const ipv4MappedDotted = host.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
-  if (ipv4MappedDotted) {
-    const inner = ipv4Match(ipv4MappedDotted[1]);
-    if (inner && isPrivateIPv4(inner)) {
-      throw new Error(
-        `MERCURY_API_BASE_URL must be publicly reachable. Got ${host} which embeds a private IPv4 address.`,
-      );
-    }
-    return;
-  }
-  const ipv4MappedHex = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
-  if (ipv4MappedHex) {
-    // Only the high 16 bits decide the private-range outcome — the
-    // `isPrivateIPv4` predicate inspects octets a + b, none of c + d.
-    // Skip parsing the low pair to avoid an unused-variable lint flag
-    // (caught by CodeRabbit on the IPv6 follow-up commit).
-    const high = Number.parseInt(ipv4MappedHex[1], 16);
-    const a = (high >> 8) & 0xff;
-    const b = high & 0xff;
-    if (isPrivateIPv4({ a, b })) {
-      throw new Error(
-        `MERCURY_API_BASE_URL must be publicly reachable. Got ${host} which embeds a private IPv4 address.`,
-      );
-    }
-    return;
-  }
-
-  // IPv6 CIDR bitmask check on the first hextet of an actual IPv6 literal.
-  //   fc00::/7  → first 7 bits = 0b1111110 → mask 0xfe00, match 0xfc00 (ULA)
-  //   fe80::/10 → first 10 bits = 0b1111111010 → mask 0xffc0, match 0xfe80 (link-local)
-  // Safe to parseInt here because we already know the host is bracketed IPv6.
-  const firstHextet = Number.parseInt(host.split(":")[0] || "0", 16);
-  if (!Number.isNaN(firstHextet)) {
-    if ((firstHextet & 0xfe00) === 0xfc00 || (firstHextet & 0xffc0) === 0xfe80) {
-      throw new Error(
-        `MERCURY_API_BASE_URL must be publicly reachable. Got ${host} which is in a private IPv6 range (fc00::/7 ULA or fe80::/10 link-local).`,
+        `MERCURY_API_BASE_URL must be publicly reachable. Got ${host} which falls in the "${range}" range.`,
       );
     }
   }
+  // Hostnames that don't parse as an IP literal are treated as DNS — accepted
+  // here. The Mercury client will reject them at request time if they don't
+  // resolve to a usable target.
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -68,9 +68,21 @@ export function validateBaseUrl(raw: string): void {
   const isIPv6Literal = rawHost.startsWith("[") && rawHost.endsWith("]");
   const host = isIPv6Literal ? rawHost.slice(1, -1) : rawHost;
 
-  if (host === "localhost") {
+  // RFC 6761 reserves the entire `.localhost` namespace as loopback —
+  // not just the bare label. `localhost.`, `foo.localhost`, and
+  // `foo.localhost.` all resolve to a loopback target on stacks that
+  // honor the spec, so a bearer token sent to any of them leaks the
+  // same way as `https://127.0.0.1/`. Reject the namespace as a
+  // whole, before the non-IPv6 fast path. (Caught by CodeRabbit on
+  // this PR.)
+  if (
+    host === "localhost" ||
+    host === "localhost." ||
+    host.endsWith(".localhost") ||
+    host.endsWith(".localhost.")
+  ) {
     throw new Error(
-      "MERCURY_API_BASE_URL must be publicly reachable. Loopback hosts are rejected.",
+      "MERCURY_API_BASE_URL must be publicly reachable. Loopback hosts (the entire .localhost namespace per RFC 6761) are rejected.",
     );
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,40 +57,92 @@ export function validateBaseUrl(raw: string): void {
     );
   }
 
-  // Unwrap bracketed IPv6 literals — `URL().hostname` keeps the brackets for
-  // IPv6 ([::1], [fe80::1]) — strip before range checks.
+  // `URL().hostname` returns IPv6 literals bracketed ([::1], [fe80::1]).
+  // DNS names and IPv4 dotted-quads come back unbracketed. The brackets
+  // are how we distinguish "this host is an IPv6 literal" from "this is
+  // a DNS name that happens to contain a hex prefix" — without that
+  // gate, a hostname like `fc00-proxy.example.com` would be wrongly
+  // rejected as ULA because `parseInt("fc00-proxy", 16)` returns 0xfc00.
+  // (Caught by CodeRabbit on this PR.)
   const rawHost = url.hostname.toLowerCase();
-  const host = rawHost.startsWith("[") && rawHost.endsWith("]") ? rawHost.slice(1, -1) : rawHost;
+  const isIPv6Literal = rawHost.startsWith("[") && rawHost.endsWith("]");
+  const host = isIPv6Literal ? rawHost.slice(1, -1) : rawHost;
 
-  if (host === "localhost" || host === "::1") {
+  if (host === "localhost") {
     throw new Error(
       "MERCURY_API_BASE_URL must be publicly reachable. Loopback hosts are rejected.",
     );
   }
 
   // IPv4: match literal a.b.c.d and reject loopback, link-local, RFC 1918.
-  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (ipv4) {
-    const a = Number(ipv4[1]);
-    const b = Number(ipv4[2]);
-    if (
-      a === 0 || //                              0.0.0.0/8      "this host"/unspecified
-      a === 127 || //                            127.0.0.0/8    loopback
-      a === 10 || //                             10.0.0.0/8     RFC 1918
-      (a === 169 && b === 254) || //             169.254.0.0/16 link-local + cloud metadata
-      (a === 192 && b === 168) || //             192.168.0.0/16 RFC 1918
-      (a === 172 && b >= 16 && b <= 31) //       172.16.0.0/12  RFC 1918
-    ) {
+  const ipv4Match = (raw: string): null | { a: number; b: number } => {
+    const m = raw.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+    if (!m) return null;
+    return { a: Number(m[1]), b: Number(m[2]) };
+  };
+
+  const isPrivateIPv4 = ({ a, b }: { a: number; b: number }): boolean =>
+    a === 0 || //                              0.0.0.0/8      "this host"/unspecified
+    a === 127 || //                            127.0.0.0/8    loopback
+    a === 10 || //                             10.0.0.0/8     RFC 1918
+    (a === 169 && b === 254) || //             169.254.0.0/16 link-local + cloud metadata
+    (a === 192 && b === 168) || //             192.168.0.0/16 RFC 1918
+    (a === 172 && b >= 16 && b <= 31); //      172.16.0.0/12  RFC 1918
+
+  if (!isIPv6Literal) {
+    const ipv4 = ipv4Match(host);
+    if (ipv4 && isPrivateIPv4(ipv4)) {
       throw new Error(
         `MERCURY_API_BASE_URL must be publicly reachable. Got ${host} which is loopback/RFC 1918/link-local/cloud-metadata.`,
       );
     }
+    return; // DNS names that aren't loopback / IPv4-private get a pass.
   }
 
-  // IPv6 CIDR bitmask check on the first hextet:
+  // From here, `host` is an IPv6 literal (brackets stripped).
+
+  // Loopback in any form: ::1, 0:0:0:0:0:0:0:1, etc.
+  // Easy invariant: collapse runs of zero hextets and check for `::1` or `0::1`.
+  const collapsedZeros = host.replace(/(?:^|:)(?:0+:)+/g, "::").replace(/::+/g, "::");
+  if (collapsedZeros === "::1" || collapsedZeros === "0::1") {
+    throw new Error(
+      "MERCURY_API_BASE_URL must be publicly reachable. Loopback hosts are rejected.",
+    );
+  }
+
+  // IPv4-mapped IPv6: re-run the IPv4 private-range check on the embedded
+  // address, otherwise `[::ffff:127.0.0.1]` would slip past. Two shapes:
+  //   - dotted-quad: `::ffff:127.0.0.1` (untouched by some parsers)
+  //   - hex pair: `::ffff:7f00:1` (Node's `URL().hostname` canonicalises to this)
+  const ipv4MappedDotted = host.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+  if (ipv4MappedDotted) {
+    const inner = ipv4Match(ipv4MappedDotted[1]);
+    if (inner && isPrivateIPv4(inner)) {
+      throw new Error(
+        `MERCURY_API_BASE_URL must be publicly reachable. Got ${host} which embeds a private IPv4 address.`,
+      );
+    }
+    return;
+  }
+  const ipv4MappedHex = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+  if (ipv4MappedHex) {
+    const high = Number.parseInt(ipv4MappedHex[1], 16);
+    const low = Number.parseInt(ipv4MappedHex[2], 16);
+    const a = (high >> 8) & 0xff;
+    const b = high & 0xff;
+    if (isPrivateIPv4({ a, b })) {
+      throw new Error(
+        `MERCURY_API_BASE_URL must be publicly reachable. Got ${host} which embeds a private IPv4 address.`,
+      );
+    }
+    return;
+  }
+
+  // IPv6 CIDR bitmask check on the first hextet of an actual IPv6 literal.
   //   fc00::/7  → first 7 bits = 0b1111110 → mask 0xfe00, match 0xfc00 (ULA)
   //   fe80::/10 → first 10 bits = 0b1111111010 → mask 0xffc0, match 0xfe80 (link-local)
-  const firstHextet = Number.parseInt(host.split(":")[0], 16);
+  // Safe to parseInt here because we already know the host is bracketed IPv6.
+  const firstHextet = Number.parseInt(host.split(":")[0] || "0", 16);
   if (!Number.isNaN(firstHextet)) {
     if ((firstHextet & 0xfe00) === 0xfc00 || (firstHextet & 0xffc0) === 0xfe80) {
       throw new Error(
@@ -108,7 +160,12 @@ export function validateBaseUrl(raw: string): void {
  * for the rule set.
  */
 export function resolveBaseUrl(apiKey: string, explicitBaseUrl?: string): string | undefined {
-  if (explicitBaseUrl) {
+  // Treat `MERCURY_API_BASE_URL=""` as a provided-but-invalid override
+  // rather than as "unset" — otherwise an operator who exports the env
+  // variable and then forgets to fill it would silently fall back to
+  // sandbox-or-prod auto-detection, defeating the fail-closed posture
+  // (caught by CodeRabbit on this PR).
+  if (explicitBaseUrl !== undefined) {
     validateBaseUrl(explicitBaseUrl);
     return explicitBaseUrl;
   }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -93,6 +93,28 @@ describe("MercuryClient", () => {
     });
   });
 
+  it('passes redirect: "manual" to fetch (fail-closed against SSRF redirect chains)', async () => {
+    let capturedInit: RequestInit | undefined;
+    global.fetch = (async (_url: URL | string, init?: RequestInit) => {
+      capturedInit = init;
+      return { ok: true, status: 200, statusText: "OK", text: async () => "{}" };
+    }) as unknown as typeof fetch;
+
+    const client = new MercuryClient({ apiKey: "key" });
+    await client.get("/accounts");
+
+    expect(capturedInit?.redirect).toBe("manual");
+  });
+
+  it("throws MercuryError on a 30x redirect response (does not leak bearer)", async () => {
+    mockFetch({ ok: false, status: 302, statusText: "Found", body: "" });
+    const client = new MercuryClient({ apiKey: "key" });
+    await expect(client.get("/accounts")).rejects.toMatchObject({
+      status: 302,
+      message: expect.stringMatching(/unexpected redirect/i),
+    });
+  });
+
   it("coerces empty response body to { ok: true }", async () => {
     mockFetch({ ok: true, status: 204, body: "" });
     const client = new MercuryClient({ apiKey: "key" });

--- a/test/safe-url-dns.test.ts
+++ b/test/safe-url-dns.test.ts
@@ -1,0 +1,62 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+const lookupMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:dns/promises", () => ({
+  lookup: lookupMock,
+}));
+
+const { assertSafeUrl } = await import("../src/safe-url.js");
+
+describe("assertSafeUrl — DNS resolution path (mocked)", () => {
+  beforeEach(() => {
+    lookupMock.mockReset();
+  });
+
+  it("rejects hostname that DNS resolves to an RFC 1918 IPv4", async () => {
+    lookupMock.mockResolvedValue([{ address: "10.0.0.1", family: 4 }]);
+    await expect(assertSafeUrl("https://example.test/api")).rejects.toThrow(
+      /DNS resolved to 10\.0\.0\.1/,
+    );
+  });
+
+  it("rejects hostname that DNS resolves to cloud-metadata link-local", async () => {
+    lookupMock.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+    await expect(assertSafeUrl("https://meta.example.test/")).rejects.toThrow(
+      /DNS resolved to 169\.254\.169\.254/,
+    );
+  });
+
+  it("rejects when any record in a multi-record reply is non-unicast", async () => {
+    lookupMock.mockResolvedValue([
+      { address: "1.1.1.1", family: 4 },
+      { address: "127.0.0.1", family: 4 },
+    ]);
+    await expect(assertSafeUrl("https://mixed.example.test/")).rejects.toThrow(
+      /DNS resolved to 127\.0\.0\.1/,
+    );
+  });
+
+  it("rejects hostname that DNS resolves to an IPv6 ULA", async () => {
+    lookupMock.mockResolvedValue([{ address: "fc00::1", family: 6 }]);
+    await expect(assertSafeUrl("https://ula.example.test/")).rejects.toThrow(
+      /DNS resolved to fc00::1/,
+    );
+  });
+
+  it("accepts hostname that DNS resolves only to public unicast IPs", async () => {
+    lookupMock.mockResolvedValue([
+      { address: "1.1.1.1", family: 4 },
+      { address: "2606:4700:4700::1111", family: 6 },
+    ]);
+    await expect(assertSafeUrl("https://safe.example.test/api")).resolves.toBeUndefined();
+  });
+
+  it("skips records whose address is not a parseable IP literal (defensive guard)", async () => {
+    // Exercises the `if (!ipaddr.isValid(r.address)) continue;` branch.
+    // node:dns normally guarantees `address` is a valid IP literal — this
+    // test pins the behaviour if a future Node change ever returns junk.
+    lookupMock.mockResolvedValue([{ address: "not-an-ip", family: 4 }]);
+    await expect(assertSafeUrl("https://garbage.example.test/")).resolves.toBeUndefined();
+  });
+});

--- a/test/safe-url.test.ts
+++ b/test/safe-url.test.ts
@@ -1,0 +1,45 @@
+import { assertSafeUrl } from "../src/safe-url.js";
+
+describe("assertSafeUrl — IP literal path (no DNS)", () => {
+  it("accepts a public IPv4 literal", async () => {
+    await expect(assertSafeUrl("https://1.1.1.1/api")).resolves.toBeUndefined();
+  });
+
+  it("rejects loopback IPv4 literal", async () => {
+    await expect(assertSafeUrl("https://127.0.0.1/api")).rejects.toThrow(/loopback/);
+  });
+
+  it("rejects RFC 1918 private IPv4 literal", async () => {
+    await expect(assertSafeUrl("https://10.0.0.1/api")).rejects.toThrow(/private/);
+    await expect(assertSafeUrl("https://192.168.1.1/api")).rejects.toThrow(/private/);
+  });
+
+  it("rejects link-local IPv4 (cloud-metadata)", async () => {
+    await expect(assertSafeUrl("https://169.254.169.254/")).rejects.toThrow(/linkLocal/);
+  });
+
+  it("rejects RFC 6598 carrier-grade NAT (100.64/10)", async () => {
+    await expect(assertSafeUrl("https://100.64.0.5/api")).rejects.toThrow(/carrierGradeNat/);
+  });
+
+  it("rejects IPv6 loopback / ULA / link-local literals", async () => {
+    await expect(assertSafeUrl("https://[::1]/api")).rejects.toThrow(/loopback/);
+    await expect(assertSafeUrl("https://[fc00::1]/api")).rejects.toThrow(/uniqueLocal/);
+    await expect(assertSafeUrl("https://[fe80::1]/api")).rejects.toThrow(/linkLocal/);
+  });
+
+  it("rejects any non-https scheme", async () => {
+    await expect(assertSafeUrl("http://1.1.1.1/api")).rejects.toThrow(/bearer token/);
+    await expect(assertSafeUrl("file:///etc/passwd")).rejects.toThrow(/bearer token/);
+  });
+
+  it("rejects RFC 6761 .localhost namespace", async () => {
+    await expect(assertSafeUrl("https://localhost/api")).rejects.toThrow(/RFC 6761/);
+    await expect(assertSafeUrl("https://foo.localhost/api")).rejects.toThrow(/RFC 6761/);
+    await expect(assertSafeUrl("https://localhost./api")).rejects.toThrow(/RFC 6761/);
+  });
+
+  it("rejects an invalid URL string", async () => {
+    await expect(assertSafeUrl("not-a-url")).rejects.toThrow(/invalid URL/);
+  });
+});

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,6 +1,12 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { createServer, resolveBaseUrl, SANDBOX_BASE_URL, VERSION } from "../src/server.js";
+import {
+  createServer,
+  resolveBaseUrl,
+  SANDBOX_BASE_URL,
+  validateBaseUrl,
+  VERSION,
+} from "../src/server.js";
 
 describe("resolveBaseUrl", () => {
   it("returns explicit baseUrl when provided", () => {
@@ -21,6 +27,46 @@ describe("resolveBaseUrl", () => {
     expect(resolveBaseUrl("secret-token:mercury_sandbox_abc", "https://override.example.com")).toBe(
       "https://override.example.com",
     );
+  });
+
+  it("throws on http:// override (no plaintext bearer leak)", () => {
+    expect(() => resolveBaseUrl("any-key", "http://attacker.tld/api")).toThrow(/https:\/\//);
+  });
+
+  it("throws on loopback override (no SSRF)", () => {
+    expect(() => resolveBaseUrl("any-key", "https://127.0.0.1/api")).toThrow(/publicly reachable/);
+    expect(() => resolveBaseUrl("any-key", "https://localhost/api")).toThrow(/Loopback/);
+  });
+
+  it("throws on RFC 1918 / link-local / cloud-metadata override", () => {
+    expect(() => resolveBaseUrl("any-key", "https://10.0.0.5/api")).toThrow(/publicly reachable/);
+    expect(() => resolveBaseUrl("any-key", "https://192.168.1.5/api")).toThrow(
+      /publicly reachable/,
+    );
+    expect(() => resolveBaseUrl("any-key", "https://172.16.0.5/api")).toThrow(/publicly reachable/);
+    expect(() => resolveBaseUrl("any-key", "https://169.254.169.254/api")).toThrow(
+      /publicly reachable/,
+    );
+  });
+
+  it("throws on IPv6 ULA / link-local override", () => {
+    expect(() => resolveBaseUrl("any-key", "https://[fc00::1]/api")).toThrow(/private IPv6/);
+    expect(() => resolveBaseUrl("any-key", "https://[fe80::1]/api")).toThrow(/private IPv6/);
+    expect(() => resolveBaseUrl("any-key", "https://[::1]/api")).toThrow(/Loopback/);
+  });
+
+  it("throws on malformed override URL", () => {
+    expect(() => resolveBaseUrl("any-key", "not-a-url")).toThrow(/not a valid URL/);
+  });
+});
+
+describe("validateBaseUrl (direct)", () => {
+  it("accepts the official Mercury production URL", () => {
+    expect(() => validateBaseUrl("https://api.mercury.com/api/v1")).not.toThrow();
+  });
+
+  it("accepts the official Mercury sandbox URL", () => {
+    expect(() => validateBaseUrl(SANDBOX_BASE_URL)).not.toThrow();
   });
 });
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -2,6 +2,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import {
   createServer,
+  MERCURY_HOSTS,
   resolveBaseUrl,
   SANDBOX_BASE_URL,
   validateBaseUrl,
@@ -123,15 +124,19 @@ describe("validateBaseUrl (direct)", () => {
     delete process.env.MERCURY_MCP_ALLOW_NON_MERCURY_HOST;
   });
 
-  it("accepts the official Mercury production URL", () => {
-    expect(() => validateBaseUrl("https://api.mercury.com/api/v1")).not.toThrow();
-  });
-
-  it("accepts the official Mercury sandbox URL", () => {
+  it("accepts every host on the strict allowlist (and the sandbox URL constant)", () => {
+    // Iterate the exported allowlist — the test purposefully does not pin
+    // literal hostnames so the allowlist can be tightened (or relaxed)
+    // without rewriting the assertion.
+    for (const allowed of MERCURY_HOSTS) {
+      expect(() => validateBaseUrl(`https://${allowed}`)).not.toThrow();
+      expect(() => validateBaseUrl(`https://${allowed}/api/v1`)).not.toThrow();
+    }
+    // SANDBOX_BASE_URL must be on the allowlist by construction.
     expect(() => validateBaseUrl(SANDBOX_BASE_URL)).not.toThrow();
   });
 
-  it("rejects other *.mercury.com subdomains by default (strict allowlist)", () => {
+  it("rejects mercury.com subdomains that aren't on the strict allowlist", () => {
     // No wildcard: any future Mercury subdomain that should ship needs an
     // explicit code-review pass before it inherits write access to the
     // bearer token.

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -131,8 +131,14 @@ describe("validateBaseUrl (direct)", () => {
     expect(() => validateBaseUrl(SANDBOX_BASE_URL)).not.toThrow();
   });
 
-  it("accepts other *.mercury.com subdomains by default", () => {
-    expect(() => validateBaseUrl("https://internal.mercury.com/api/v1")).not.toThrow();
+  it("rejects other *.mercury.com subdomains by default (strict allowlist)", () => {
+    // No wildcard: any future Mercury subdomain that should ship needs an
+    // explicit code-review pass before it inherits write access to the
+    // bearer token.
+    expect(() => validateBaseUrl("https://internal.mercury.com/api/v1")).toThrow(
+      /not a Mercury hostname/,
+    );
+    expect(() => validateBaseUrl("https://docs.mercury.com")).toThrow(/not a Mercury hostname/);
   });
 
   it("rejects non-Mercury hosts by default (no opt-in)", () => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -47,53 +47,48 @@ describe("resolveBaseUrl", () => {
     expect(() => resolveBaseUrl("any-key", "https://foo.bar.localhost./api")).toThrow(/Loopback/);
   });
 
+  // The user-facing error message is decoupled from `ipaddr.js`'s internal
+  // taxonomy (uniqueLocal / carrierGradeNat / reserved / etc.). All non-public
+  // ranges throw the same stable "non-public range" message; the raw
+  // ipaddr.js label is logged to stderr for debug-level diagnosis instead.
+  // Tests therefore match the stable substring rather than library labels.
+
   it("throws on RFC 1918 / link-local / cloud-metadata override", () => {
-    expect(() => resolveBaseUrl("any-key", "https://10.0.0.5/api")).toThrow(/publicly reachable/);
-    expect(() => resolveBaseUrl("any-key", "https://192.168.1.5/api")).toThrow(
-      /publicly reachable/,
-    );
-    expect(() => resolveBaseUrl("any-key", "https://172.16.0.5/api")).toThrow(/publicly reachable/);
+    expect(() => resolveBaseUrl("any-key", "https://10.0.0.5/api")).toThrow(/non-public range/);
+    expect(() => resolveBaseUrl("any-key", "https://192.168.1.5/api")).toThrow(/non-public range/);
+    expect(() => resolveBaseUrl("any-key", "https://172.16.0.5/api")).toThrow(/non-public range/);
     expect(() => resolveBaseUrl("any-key", "https://169.254.169.254/api")).toThrow(
-      /publicly reachable/,
+      /non-public range/,
     );
   });
 
-  it("throws on IPv6 ULA / link-local override", () => {
-    // `ipaddr.js` classifies fc00::/7 as `uniqueLocal`, fe80::/10 as
-    // `linkLocal`, ::1 as `loopback` — all rejected as non-`unicast`.
-    expect(() => resolveBaseUrl("any-key", "https://[fc00::1]/api")).toThrow(/uniqueLocal/);
-    expect(() => resolveBaseUrl("any-key", "https://[fe80::1]/api")).toThrow(/linkLocal/);
-    expect(() => resolveBaseUrl("any-key", "https://[::1]/api")).toThrow(/loopback/);
+  it("throws on IPv6 ULA / link-local / loopback override", () => {
+    expect(() => resolveBaseUrl("any-key", "https://[fc00::1]/api")).toThrow(/non-public range/);
+    expect(() => resolveBaseUrl("any-key", "https://[fe80::1]/api")).toThrow(/non-public range/);
+    expect(() => resolveBaseUrl("any-key", "https://[::1]/api")).toThrow(/non-public range/);
   });
 
-  it("throws on IPv4-mapped IPv6 loopback (::ffff:127.0.0.1)", () => {
-    // ipaddr.js normalises the mapped form into the underlying IPv4 range
-    // so the same loopback classification applies as for bare 127.0.0.1.
-    expect(() => resolveBaseUrl("any-key", "https://[::ffff:127.0.0.1]/api")).toThrow(/loopback/);
-  });
-
-  it("throws on hex-pair IPv4-mapped loopback (::ffff:7f00:1)", () => {
-    // Node's URL.hostname canonicalises `::ffff:127.0.0.1` to `::ffff:7f00:1`.
-    // Verify the hex-pair form is also caught.
-    expect(() => resolveBaseUrl("any-key", "https://[::ffff:7f00:1]/api")).toThrow(/loopback/);
+  it("throws on IPv4-mapped IPv6 loopback in both encodings", () => {
+    // ipaddr.js normalises both `::ffff:127.0.0.1` (dotted) and Node's
+    // canonical `::ffff:7f00:1` (hex-pair) into the underlying IPv4 range.
+    expect(() => resolveBaseUrl("any-key", "https://[::ffff:127.0.0.1]/api")).toThrow(
+      /non-public range/,
+    );
+    expect(() => resolveBaseUrl("any-key", "https://[::ffff:7f00:1]/api")).toThrow(
+      /non-public range/,
+    );
   });
 
   it("throws on expanded IPv6 loopback form (0:0:0:0:0:0:0:1)", () => {
-    expect(() => resolveBaseUrl("any-key", "https://[0:0:0:0:0:0:0:1]/api")).toThrow(/loopback/);
+    expect(() => resolveBaseUrl("any-key", "https://[0:0:0:0:0:0:0:1]/api")).toThrow(
+      /non-public range/,
+    );
   });
 
-  it("throws on RFC 6598 carrier-grade NAT range (100.64/10)", () => {
-    expect(() => resolveBaseUrl("any-key", "https://100.64.0.5/api")).toThrow(/carrierGradeNat/);
-  });
-
-  it("throws on RFC 2544 benchmarking range (198.18/15)", () => {
-    // ipaddr.js groups the RFC 2544 benchmarking range under the catch-all
-    // `reserved` classification — it is still rejected as non-`unicast`.
-    expect(() => resolveBaseUrl("any-key", "https://198.18.0.5/api")).toThrow(/reserved/);
-  });
-
-  it("throws on RFC 5737 documentation ranges (TEST-NET)", () => {
-    expect(() => resolveBaseUrl("any-key", "https://192.0.2.5/api")).toThrow(/reserved/);
+  it("throws on RFC 6598 carrier-grade NAT (100.64/10) and RFC 2544 / 5737 reserved ranges", () => {
+    expect(() => resolveBaseUrl("any-key", "https://100.64.0.5/api")).toThrow(/non-public range/);
+    expect(() => resolveBaseUrl("any-key", "https://198.18.0.5/api")).toThrow(/non-public range/);
+    expect(() => resolveBaseUrl("any-key", "https://192.0.2.5/api")).toThrow(/non-public range/);
   });
 
   it("does NOT misclassify DNS hostnames that contain hex-prefix substrings as IPv6", () => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -55,6 +55,28 @@ describe("resolveBaseUrl", () => {
     expect(() => resolveBaseUrl("any-key", "https://[::1]/api")).toThrow(/Loopback/);
   });
 
+  it("throws on IPv4-mapped IPv6 loopback (::ffff:127.0.0.1)", () => {
+    expect(() => resolveBaseUrl("any-key", "https://[::ffff:127.0.0.1]/api")).toThrow(
+      /private IPv4/,
+    );
+  });
+
+  it("throws on expanded IPv6 loopback form (0:0:0:0:0:0:0:1)", () => {
+    expect(() => resolveBaseUrl("any-key", "https://[0:0:0:0:0:0:0:1]/api")).toThrow(/Loopback/);
+  });
+
+  it("does NOT misclassify DNS hostnames that contain hex-prefix substrings as IPv6", () => {
+    // `fc00-proxy.example.com` is a perfectly valid DNS name — the previous
+    // code wrongly rejected it because parseInt("fc00-proxy", 16) === 0xfc00
+    // tripped the ULA bitmask. Bracketed-IPv6 gating fixes it.
+    expect(() => resolveBaseUrl("any-key", "https://fc00-proxy.example.com/api")).not.toThrow();
+    expect(() => resolveBaseUrl("any-key", "https://fe80-host.example.com/api")).not.toThrow();
+  });
+
+  it("treats empty string override as invalid (fail-closed)", () => {
+    expect(() => resolveBaseUrl("any-key", "")).toThrow(/not a valid URL/);
+  });
+
   it("throws on malformed override URL", () => {
     expect(() => resolveBaseUrl("any-key", "not-a-url")).toThrow(/not a valid URL/);
   });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -59,19 +59,41 @@ describe("resolveBaseUrl", () => {
   });
 
   it("throws on IPv6 ULA / link-local override", () => {
-    expect(() => resolveBaseUrl("any-key", "https://[fc00::1]/api")).toThrow(/private IPv6/);
-    expect(() => resolveBaseUrl("any-key", "https://[fe80::1]/api")).toThrow(/private IPv6/);
-    expect(() => resolveBaseUrl("any-key", "https://[::1]/api")).toThrow(/Loopback/);
+    // `ipaddr.js` classifies fc00::/7 as `uniqueLocal`, fe80::/10 as
+    // `linkLocal`, ::1 as `loopback` — all rejected as non-`unicast`.
+    expect(() => resolveBaseUrl("any-key", "https://[fc00::1]/api")).toThrow(/uniqueLocal/);
+    expect(() => resolveBaseUrl("any-key", "https://[fe80::1]/api")).toThrow(/linkLocal/);
+    expect(() => resolveBaseUrl("any-key", "https://[::1]/api")).toThrow(/loopback/);
   });
 
   it("throws on IPv4-mapped IPv6 loopback (::ffff:127.0.0.1)", () => {
-    expect(() => resolveBaseUrl("any-key", "https://[::ffff:127.0.0.1]/api")).toThrow(
-      /private IPv4/,
-    );
+    // ipaddr.js normalises the mapped form into the underlying IPv4 range
+    // so the same loopback classification applies as for bare 127.0.0.1.
+    expect(() => resolveBaseUrl("any-key", "https://[::ffff:127.0.0.1]/api")).toThrow(/loopback/);
+  });
+
+  it("throws on hex-pair IPv4-mapped loopback (::ffff:7f00:1)", () => {
+    // Node's URL.hostname canonicalises `::ffff:127.0.0.1` to `::ffff:7f00:1`.
+    // Verify the hex-pair form is also caught.
+    expect(() => resolveBaseUrl("any-key", "https://[::ffff:7f00:1]/api")).toThrow(/loopback/);
   });
 
   it("throws on expanded IPv6 loopback form (0:0:0:0:0:0:0:1)", () => {
-    expect(() => resolveBaseUrl("any-key", "https://[0:0:0:0:0:0:0:1]/api")).toThrow(/Loopback/);
+    expect(() => resolveBaseUrl("any-key", "https://[0:0:0:0:0:0:0:1]/api")).toThrow(/loopback/);
+  });
+
+  it("throws on RFC 6598 carrier-grade NAT range (100.64/10)", () => {
+    expect(() => resolveBaseUrl("any-key", "https://100.64.0.5/api")).toThrow(/carrierGradeNat/);
+  });
+
+  it("throws on RFC 2544 benchmarking range (198.18/15)", () => {
+    // ipaddr.js groups the RFC 2544 benchmarking range under the catch-all
+    // `reserved` classification — it is still rejected as non-`unicast`.
+    expect(() => resolveBaseUrl("any-key", "https://198.18.0.5/api")).toThrow(/reserved/);
+  });
+
+  it("throws on RFC 5737 documentation ranges (TEST-NET)", () => {
+    expect(() => resolveBaseUrl("any-key", "https://192.0.2.5/api")).toThrow(/reserved/);
   });
 
   it("does NOT misclassify DNS hostnames that contain hex-prefix substrings as IPv6", () => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -38,6 +38,15 @@ describe("resolveBaseUrl", () => {
     expect(() => resolveBaseUrl("any-key", "https://localhost/api")).toThrow(/Loopback/);
   });
 
+  it("rejects the full .localhost namespace (RFC 6761)", () => {
+    // `localhost.` (trailing dot), `foo.localhost`, and `foo.localhost.`
+    // are all reserved as loopback in RFC 6761 — sending a bearer to any
+    // of them leaks the same way as `https://127.0.0.1/`.
+    expect(() => resolveBaseUrl("any-key", "https://localhost./api")).toThrow(/Loopback/);
+    expect(() => resolveBaseUrl("any-key", "https://foo.localhost/api")).toThrow(/Loopback/);
+    expect(() => resolveBaseUrl("any-key", "https://foo.bar.localhost./api")).toThrow(/Loopback/);
+  });
+
   it("throws on RFC 1918 / link-local / cloud-metadata override", () => {
     expect(() => resolveBaseUrl("any-key", "https://10.0.0.5/api")).toThrow(/publicly reachable/);
     expect(() => resolveBaseUrl("any-key", "https://192.168.1.5/api")).toThrow(

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -9,6 +9,16 @@ import {
 } from "../src/server.js";
 
 describe("resolveBaseUrl", () => {
+  // Most tests exercise non-Mercury hostnames; opt them in via the
+  // explicit env-var so the validator's Mercury-only default doesn't
+  // mask the property under test.
+  beforeEach(() => {
+    process.env.MERCURY_MCP_ALLOW_NON_MERCURY_HOST = "true";
+  });
+  afterEach(() => {
+    delete process.env.MERCURY_MCP_ALLOW_NON_MERCURY_HOST;
+  });
+
   it("returns explicit baseUrl when provided", () => {
     expect(resolveBaseUrl("any-key", "https://custom.example.com/v1")).toBe(
       "https://custom.example.com/v1",
@@ -109,12 +119,52 @@ describe("resolveBaseUrl", () => {
 });
 
 describe("validateBaseUrl (direct)", () => {
+  afterEach(() => {
+    delete process.env.MERCURY_MCP_ALLOW_NON_MERCURY_HOST;
+  });
+
   it("accepts the official Mercury production URL", () => {
     expect(() => validateBaseUrl("https://api.mercury.com/api/v1")).not.toThrow();
   });
 
   it("accepts the official Mercury sandbox URL", () => {
     expect(() => validateBaseUrl(SANDBOX_BASE_URL)).not.toThrow();
+  });
+
+  it("accepts other *.mercury.com subdomains by default", () => {
+    expect(() => validateBaseUrl("https://internal.mercury.com/api/v1")).not.toThrow();
+  });
+
+  it("rejects non-Mercury hosts by default (no opt-in)", () => {
+    expect(() => validateBaseUrl("https://attacker.example.com/api")).toThrow(
+      /not a Mercury hostname/,
+    );
+    expect(() => validateBaseUrl("https://my-proxy.example.com/api")).toThrow(
+      /not a Mercury hostname/,
+    );
+  });
+
+  it("accepts non-Mercury hosts when MERCURY_MCP_ALLOW_NON_MERCURY_HOST=true", () => {
+    process.env.MERCURY_MCP_ALLOW_NON_MERCURY_HOST = "true";
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(() => validateBaseUrl("https://my-proxy.example.com/api")).not.toThrow();
+      // Loud warning surfaced.
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("non-Mercury host"));
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("does NOT accept other truthy values for the opt-in (only the literal 'true')", () => {
+    process.env.MERCURY_MCP_ALLOW_NON_MERCURY_HOST = "1";
+    expect(() => validateBaseUrl("https://my-proxy.example.com/api")).toThrow(
+      /not a Mercury hostname/,
+    );
+    process.env.MERCURY_MCP_ALLOW_NON_MERCURY_HOST = "yes";
+    expect(() => validateBaseUrl("https://my-proxy.example.com/api")).toThrow(
+      /not a Mercury hostname/,
+    );
   });
 });
 
@@ -141,13 +191,20 @@ describe("createServer", () => {
   });
 
   it("does NOT log sandbox when explicit baseUrl overrides", () => {
+    process.env.MERCURY_MCP_ALLOW_NON_MERCURY_HOST = "true";
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const logs: string[] = [];
-    createServer({
-      apiKey: "secret-token:mercury_sandbox_abc",
-      baseUrl: "https://my-proxy.example.com/v1",
-      log: (m) => logs.push(m),
-    });
-    expect(logs.some((l) => l.includes("sandbox"))).toBe(false);
+    try {
+      createServer({
+        apiKey: "secret-token:mercury_sandbox_abc",
+        baseUrl: "https://my-proxy.example.com/v1",
+        log: (m) => logs.push(m),
+      });
+      expect(logs.some((l) => l.includes("sandbox"))).toBe(false);
+    } finally {
+      errSpy.mockRestore();
+      delete process.env.MERCURY_MCP_ALLOW_NON_MERCURY_HOST;
+    }
   });
 
   it("does NOT log sandbox for production tokens", () => {


### PR DESCRIPTION
## Summary
Add `validateBaseUrl()` defense-in-depth on the `MERCURY_API_BASE_URL` env override. Closes the MEDIUM finding from today's Docker MCP Registry-style security review.

## Why
The bearer token + every API call is sent to the resolved base URL. The previous code passed the env value through unchanged, so a misconfigured operator (or a host that lets prompt-injected content reach env composition) could set `MERCURY_API_BASE_URL=http://attacker.tld` and silently exfiltrate credentials. The defense was asymmetric: outbound webhook URLs already had a strict `HttpsWebhookUrl` validator, but the inbound base URL had none.

## Rules (mirror `HttpsWebhookUrl`)
- HTTPS required — rejects `http://`, `file://`, `data:`, `ftp://`, etc.
- Loopback (127.0.0.0/8, `::1`, `localhost`) blocked.
- RFC 1918 (10/8, 192.168/16, 172.16-31/12) blocked.
- Link-local (169.254/16) + cloud-metadata blocked.
- IPv6 ULA (`fc00::/7`) + link-local (`fe80::/10`) blocked.

The official `https://api.mercury.com/api/v1` + sandbox URL both pass. Legitimate self-hosted proxies that follow the same rules pass. Misconfigured or attacker-supplied overrides throw at boot with a clear stderr message.

## Test plan
- [x] `npm test` — 190/190 pass (was 183, +7 new validateBaseUrl cases)
- [x] `npm run format:check` clean
- [x] `npm run lint` clean
- [x] Build green via `tsup`
- [ ] CI green
- [ ] CodeRabbit + Qodo review

No runtime change for callers using the official URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stricter base-URL allowlist and runtime safety gate for outbound requests; non-official hosts are only allowed when explicitly enabled (with a warning).

* **Bug Fixes**
  * Fail-closed override handling: empty-string overrides are validated and rejected; HTTPS required; `.localhost` and non-unicast/private/link-local/CGNAT/ULA IPs blocked.

* **Tests**
  * Expanded unit tests for DNS/IP resolution, SSRF/regression cases, and malformed/edge inputs.

* **Chores**
  * Added IP parsing dependency for runtime validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->