### PR TITLE
chore(hardening): close LOW/INFO findings from security review

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -42,21 +42,28 @@ maintainer commits to, and limits that callers must account for.
   `"Mercury API error 429: …"` via the `MercuryError` branch.
 - **Optional audit trail**: `MERCURY_MCP_AUDIT_LOG=/abs/path/audit.log` writes
   an append-only JSON Lines record (file mode `0o600`, sensitive fields
-  redacted) of every write call.
+  redacted) of every write call. The parent directory is pre-created at
+  mode `0o700` so the log does not sit inside a world-readable directory.
+  Single-generation rotation kicks in at
+  `MERCURY_MCP_AUDIT_LOG_MAX_BYTES` (default 50 MB): the live log is renamed
+  to `<path>.1` (overwriting any previous `.1`) and a fresh log is opened.
+  Operators who need a longer retention chain should compose this with their
+  own `logrotate` recipe.
 - **Persistent rate-limit state**: the rate-limit window survives MCP process
   restarts. State is written to `~/.mercury-mcp/ratelimit.json` (mode `0o600`,
   atomic `rename` of a per-write tmp file with PID+UUID suffix) by default;
   override with `MERCURY_MCP_STATE_DIR=/abs/path`. Without persistence, an MCP
   host that respawns the server per session would reset the counter and
-  silently bypass the limit. **Single-process semantics**: this MCP assumes
-  one process per `MERCURY_MCP_STATE_DIR` at a time. If you run two MCP hosts
-  concurrently against the same state directory (e.g. Claude Desktop and
-  Cursor on the same user account), the read-modify-write cycle is not
-  inter-process locked — the last writer wins and an in-flight call recorded
-  by the other process can be dropped, slightly under-counting against the
-  per-day limit. Mercury's own server-side limits remain authoritative; for
-  this MCP's local cap, treat the local rate-limit as best-effort under
-  concurrent-host conditions. **Persistent unreadable state**: if the state
+  silently bypass the limit. **Inter-process serialisation**: the
+  load → check → append → persist cycle runs under a sibling
+  `ratelimit.json.lock` lockfile created with `O_EXCL`. Two MCP hosts on the
+  same state dir (Claude Desktop and Cursor on the same user account)
+  serialise their writes through the lock, eliminating the previous
+  under-count race. Stale locks (process killed between open and unlink)
+  are reclaimed automatically after a short grace window. Under sustained
+  contention beyond a 2 s timeout, the middleware falls through without the
+  lock — the documented worst case is a small under-count that Mercury's
+  server-side limits still bound. **Persistent unreadable state**: if the state
   file becomes chronically unreadable mid-session (`EACCES`, `EIO`, broken
   mount, container respawn without the volume), the middleware logs a
   warning, refuses to overwrite the file (so the prior counter is

--- a/socket.yml
+++ b/socket.yml
@@ -22,6 +22,10 @@ githubApp:
   pullRequestAlertsEnabled: true
   secretAlertsEnabled: true
 
+# REVIEW BY 2027-04 — annual audit checkpoint for the suppressions below.
+# Each entry is intentional today; drift over time (new transitive deps,
+# changed Socket categorisation) could turn a justified suppression into
+# a blind spot. Re-read every `false` and re-confirm before extending.
 issueRules:
   # Silence the alerts that are intrinsic to what this MCP does (read env,
   # read local rate-limit state, call the Mercury Banking API, hardcode the

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,13 +10,41 @@ export interface MercuryClientOptions {
   baseUrl?: string;
 }
 
+/**
+ * Cap on `MercuryError.message` length. Mercury error messages can
+ * legitimately echo upstream content (an invoice memo, a counterparty
+ * name, a rejected field) that an attacker may have influenced. The
+ * fence + control-char strip in `sanitizeForLlm` already neutralise
+ * the structural risk; the cap is a *budget* control to stop a
+ * pathological 1 MB error from saturating the LLM context window.
+ *
+ * The cut is structured: keep the first ~half of the budget and the
+ * last ~half, with a clearly labelled marker in between, so a reader
+ * (human or model) sees both the leading and trailing context. Net
+ * length is bounded by `MERCURY_ERROR_MESSAGE_MAX` plus the marker.
+ */
+export const MERCURY_ERROR_MESSAGE_MAX = 2048;
+const TRUNCATION_MARKER = " ... [truncated] ... ";
+
+function capErrorMessage(message: string, max: number = MERCURY_ERROR_MESSAGE_MAX): string {
+  if (message.length <= max) return message;
+  // Reserve the marker length out of the budget so the final string is
+  // always ≤ max + marker (predictable upper bound for callers).
+  const headLen = Math.ceil((max - TRUNCATION_MARKER.length) / 2);
+  const tailLen = Math.floor((max - TRUNCATION_MARKER.length) / 2);
+  return message.slice(0, headLen) + TRUNCATION_MARKER + message.slice(-tailLen);
+}
+
 export class MercuryError extends Error {
   constructor(
     message: string,
     public status: number,
     public body?: unknown,
   ) {
-    super(message);
+    // Cap upstream-influenced bytes at the source so every consumer of
+    // `err.message` (the LLM error channel, logs, debuggers) sees the
+    // same bounded value.
+    super(capErrorMessage(message));
     this.name = "MercuryError";
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,7 +18,17 @@
  *   MERCURY_MCP_RATE_LIMIT_DISABLE=true    # disable all limits
  */
 
-import { appendFileSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
@@ -167,8 +177,8 @@ function persistCallHistory(): void {
   // Per-write unique tmp filename so two MCP processes that both call
   // persistCallHistory at the same instant cannot clobber each other's
   // tmp file before either rename completes. The rename itself is atomic.
-  // Caveat: this still does not give us inter-process serialization of the
-  // read-modify-write cycle — see .github/SECURITY.md "single-process state" entry.
+  // Inter-process serialization of the read-modify-write cycle is provided
+  // by the O_EXCL lockfile around the call site — see withRateLimitLock.
   const tmp = `${path}.${process.pid}.${randomUUID()}.tmp`;
   try {
     mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
@@ -178,6 +188,118 @@ function persistCallHistory(): void {
     renameSync(tmp, path);
   } catch (err) {
     console.error(`[ratelimit] failed to persist state to ${path}: ${(err as Error).message}`);
+  }
+}
+
+/**
+ * Inter-process lock for the rate-limit read-modify-write cycle.
+ *
+ * Two MCP hosts (Claude Desktop + Cursor on the same user account) can
+ * both invoke a write tool at the same instant. Each independently does
+ * load → check → append → persist. Without serialization the second
+ * process can clobber the first — under-counting against the per-day
+ * limit by 1-2 entries in a worst-case race.
+ *
+ * `O_EXCL` on a lockfile sibling to `ratelimit.json` gives us a
+ * filesystem-level mutex. The lock window covers the in-memory reload
+ * plus the persist. Same `MERCURY_MCP_STATE_DIR` precondition as the
+ * state file itself (already pre-created at `0o700`).
+ *
+ * Stale-lock recovery: if a prior process crashed between `openSync`
+ * and `rmSync`, the lockfile remains. We treat any lock older than
+ * `LOCK_STALE_MS` as abandoned and reclaim it. The wall-clock comparison
+ * is loose-by-design — a 5s window is comfortably longer than any
+ * legitimate RMW (a few ms) but short enough that recovery on
+ * crash/SIGKILL is automatic on the next call.
+ */
+const LOCK_TIMEOUT_MS = 2_000;
+const LOCK_STALE_MS = 5_000;
+const LOCK_RETRY_MS = 25;
+
+function getLockFile(): string {
+  return `${getStateFile()}.lock`;
+}
+
+/**
+ * Synchronous sleep for sync rate-limit retry. `Atomics.wait` on a tiny
+ * SharedArrayBuffer is the cleanest way to block a sync function for a
+ * fixed wall-clock duration (no `child_process.execSync('sleep')` cost,
+ * no busy loop burning CPU).
+ */
+function sleepSync(ms: number): void {
+  const buf = new SharedArrayBuffer(4);
+  const view = new Int32Array(buf);
+  Atomics.wait(view, 0, 0, ms);
+}
+
+function withRateLimitLock<T>(fn: () => T): T {
+  const lockPath = getLockFile();
+  // Best-effort: ensure the parent dir exists. mkdirSync is idempotent,
+  // and persistCallHistory does this too — but if we fail to acquire
+  // the lock here we still want a meaningful error path.
+  try {
+    mkdirSync(dirname(lockPath), { recursive: true, mode: 0o700 });
+  } catch {
+    /* fall through: openSync below will surface the real error */
+  }
+  const start = Date.now();
+  while (true) {
+    let fd: number | undefined;
+    try {
+      // O_WRONLY | O_CREAT | O_EXCL — fails with EEXIST if already held.
+      fd = openSync(lockPath, "wx", 0o600);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") {
+        // Anything other than EEXIST (EACCES on a read-only state dir,
+        // ENOENT on a vanished mount, etc.) means we cannot hold the
+        // lock at all. Fall through without it; the documented worst
+        // case is an under-count by 1-2 entries.
+        console.error(
+          `[ratelimit] cannot create lockfile ${lockPath}: ${(err as Error).message}; proceeding without inter-process lock`,
+        );
+        return fn();
+      }
+      // Stale-lock detection: reclaim a lockfile whose mtime is older
+      // than LOCK_STALE_MS (process crashed between open and unlink).
+      try {
+        const stat = statSync(lockPath);
+        if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+          rmSync(lockPath, { force: true });
+          continue;
+        }
+      } catch {
+        /* lock disappeared between EEXIST and stat — retry immediately */
+        continue;
+      }
+      if (Date.now() - start > LOCK_TIMEOUT_MS) {
+        // Best-effort: never block the tool call indefinitely on a busy
+        // lock. Fall through without a lock; the worst case is the
+        // documented under-count by 1-2 entries.
+        console.error(
+          `[ratelimit] lock contention on ${lockPath} after ${LOCK_TIMEOUT_MS}ms; proceeding without inter-process lock`,
+        );
+        return fn();
+      }
+      sleepSync(LOCK_RETRY_MS);
+      continue;
+    }
+    try {
+      return fn();
+    } finally {
+      // Order matters: close before rm so we don't unlink a file we
+      // still hold an fd on (POSIX is fine with it, but Windows isn't).
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+      try {
+        rmSync(lockPath, { force: true });
+      } catch {
+        /* lock already gone */
+      }
+    }
   }
 }
 
@@ -228,28 +350,37 @@ export function enforceRateLimit(toolName: string): void {
   const limits = getBucketLimit(bucket);
   if (!limits) return;
 
-  loadCallHistory();
+  // The whole load → check → append → persist cycle runs under an
+  // O_EXCL lockfile so concurrent MCP hosts on the same state dir
+  // serialise their RMW. `loadCallHistory` is re-run inside the lock
+  // (after resetting `stateLoaded`) to pick up writes from any peer
+  // that held the lock immediately before us — otherwise we would
+  // count against a stale in-memory snapshot.
+  withRateLimitLock(() => {
+    stateLoaded = false;
+    loadCallHistory();
 
-  const now = Date.now();
-  // Prune: keep only records within the monthly window
-  const records = (callHistory.get(bucket) ?? []).filter((ts) => now - ts < MONTH_MS);
+    const now = Date.now();
+    // Prune: keep only records within the monthly window
+    const records = (callHistory.get(bucket) ?? []).filter((ts) => now - ts < MONTH_MS);
 
-  // Daily window: records within the last 24h
-  const dailyRecords = records.filter((ts) => now - ts < DAY_MS);
-  if (dailyRecords.length >= limits.daily) {
-    const retryAfterMs = DAY_MS - (now - dailyRecords[0]);
-    throw new RateLimitError(toolName, bucket, "daily", limits.daily, retryAfterMs);
-  }
+    // Daily window: records within the last 24h
+    const dailyRecords = records.filter((ts) => now - ts < DAY_MS);
+    if (dailyRecords.length >= limits.daily) {
+      const retryAfterMs = DAY_MS - (now - dailyRecords[0]);
+      throw new RateLimitError(toolName, bucket, "daily", limits.daily, retryAfterMs);
+    }
 
-  // Monthly window: records is already pruned to 30 days
-  if (records.length >= limits.monthly) {
-    const retryAfterMs = MONTH_MS - (now - records[0]);
-    throw new RateLimitError(toolName, bucket, "monthly", limits.monthly, retryAfterMs);
-  }
+    // Monthly window: records is already pruned to 30 days
+    if (records.length >= limits.monthly) {
+      const retryAfterMs = MONTH_MS - (now - records[0]);
+      throw new RateLimitError(toolName, bucket, "monthly", limits.monthly, retryAfterMs);
+    }
 
-  records.push(now);
-  callHistory.set(bucket, records);
-  persistCallHistory();
+    records.push(now);
+    callHistory.set(bucket, records);
+    persistCallHistory();
+  });
 }
 
 export function isDryRun(): boolean {
@@ -288,6 +419,58 @@ export function redactSensitive(value: unknown): unknown {
   return out;
 }
 
+/**
+ * Default audit-log rotation threshold: 50 MB. Matches the in-line
+ * default surfaced in `getAuditLogMaxBytes` so callers reading the
+ * source see the same number twice.
+ */
+const DEFAULT_AUDIT_LOG_MAX_BYTES = 50 * 1024 * 1024;
+
+/**
+ * Parse `MERCURY_MCP_AUDIT_LOG_MAX_BYTES` if set. Falls back to the
+ * default when the env var is missing, malformed, zero, or negative.
+ * Logs a single warning on bad input so an operator can fix the typo
+ * without auditing breaking entirely.
+ */
+function getAuditLogMaxBytes(): number {
+  const raw = process.env.MERCURY_MCP_AUDIT_LOG_MAX_BYTES;
+  if (!raw) return DEFAULT_AUDIT_LOG_MAX_BYTES;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.error(
+      `[audit] invalid MERCURY_MCP_AUDIT_LOG_MAX_BYTES=${raw}; falling back to default ${DEFAULT_AUDIT_LOG_MAX_BYTES} bytes`,
+    );
+    return DEFAULT_AUDIT_LOG_MAX_BYTES;
+  }
+  return parsed;
+}
+
+/**
+ * Rotate the audit log if it exceeds the byte cap. Single-generation
+ * rotation: `<path>` becomes `<path>.1`, overwriting any previous `.1`.
+ * Operators who want a longer retention chain should still run their
+ * own `logrotate` recipe.
+ */
+function rotateAuditLogIfNeeded(path: string, maxBytes: number): void {
+  let size: number;
+  try {
+    size = statSync(path).size;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return; // not yet created — nothing to rotate
+    // EACCES / EIO / etc.: refuse to rotate; the next appendFileSync
+    // will surface the same problem with a clearer message.
+    console.error(`[audit] cannot stat ${path} for rotation: ${(err as Error).message}`);
+    return;
+  }
+  if (size < maxBytes) return;
+  try {
+    renameSync(path, `${path}.1`);
+  } catch (err) {
+    console.error(`[audit] failed to rotate ${path}: ${(err as Error).message}`);
+  }
+}
+
 export function logAudit(
   toolName: string,
   args: unknown,
@@ -299,6 +482,19 @@ export function logAudit(
     console.error(`[audit] MERCURY_MCP_AUDIT_LOG must be an absolute path; got: ${path}`);
     return;
   }
+  // Mirror the state-file pattern: pre-create the parent dir at 0o700
+  // so the audit log doesn't sit inside a world-readable directory on
+  // a multi-tenant host where the operator forgot to chmod the parent.
+  // mkdirSync is idempotent on { recursive: true }; the mode is only
+  // applied to dirs the call actually creates, so a pre-existing dir
+  // keeps its original mode (don't widen, don't narrow).
+  try {
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  } catch (err) {
+    console.error(`[audit] failed to create dir for ${path}: ${(err as Error).message}`);
+    // fall through: appendFileSync below will surface the real error
+  }
+  rotateAuditLogIfNeeded(path, getAuditLogMaxBytes());
   const entry = JSON.stringify({
     ts: new Date().toISOString(),
     tool: toolName,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -226,11 +226,15 @@ function getLockFile(): string {
  * fixed wall-clock duration (no `child_process.execSync('sleep')` cost,
  * no busy loop burning CPU).
  */
+/* v8 ignore start -- only reached when EEXIST contention triggers a retry;
+   exercising it deterministically would need a multi-process test harness
+   that isn't worth the maintenance cost for a 3-line sleep helper */
 function sleepSync(ms: number): void {
   const buf = new SharedArrayBuffer(4);
   const view = new Int32Array(buf);
   Atomics.wait(view, 0, 0, ms);
 }
+/* v8 ignore stop */
 
 function withRateLimitLock<T>(fn: () => T): T {
   const lockPath = getLockFile();
@@ -269,9 +273,16 @@ function withRateLimitLock<T>(fn: () => T): T {
           continue;
         }
       } catch {
-        /* lock disappeared between EEXIST and stat — retry immediately */
+        /* v8 ignore next -- TOCTOU race: lock disappeared between EEXIST
+           and stat. Reaches this branch only when another process unlinks
+           the lockfile in a sub-millisecond window — not deterministically
+           testable in a unit-test harness. */
         continue;
       }
+      /* v8 ignore start -- LOCK_TIMEOUT_MS is 2 seconds in production; a
+         deterministic test would either force a 2 s sleep on every CI
+         run or stub Date.now() across the whole module. Both are worse
+         trades than leaving this defense-in-depth fallback uncovered. */
       if (Date.now() - start > LOCK_TIMEOUT_MS) {
         // Best-effort: never block the tool call indefinitely on a busy
         // lock. Fall through without a lock; the worst case is the
@@ -283,6 +294,7 @@ function withRateLimitLock<T>(fn: () => T): T {
       }
       sleepSync(LOCK_RETRY_MS);
       continue;
+      /* v8 ignore stop */
     }
     try {
       return fn();
@@ -460,13 +472,19 @@ function rotateAuditLogIfNeeded(path: string, maxBytes: number): void {
     if (code === "ENOENT") return; // not yet created — nothing to rotate
     // EACCES / EIO / etc.: refuse to rotate; the next appendFileSync
     // will surface the same problem with a clearer message.
+    /* v8 ignore start -- statSync error path other than ENOENT (EACCES,
+       EIO, ELOOP, …) needs a hostile filesystem state we don't simulate
+       in unit tests. */
     console.error(`[audit] cannot stat ${path} for rotation: ${(err as Error).message}`);
     return;
+    /* v8 ignore stop */
   }
   if (size < maxBytes) return;
   try {
     renameSync(path, `${path}.1`);
   } catch (err) {
+    /* v8 ignore next -- renameSync error path: same reason as the
+       statSync fallback above. */
     console.error(`[audit] failed to rotate ${path}: ${(err as Error).message}`);
   }
 }

--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -163,7 +163,9 @@ export function registerTransactionTools(server: McpServer, client: MercuryClien
       idempotencyKey: z
         .string()
         .optional()
-        .describe("Unique key to prevent duplicate transfers. Auto-generated if omitted."),
+        .describe(
+          "Unique key to prevent duplicate transfers. Auto-generated if omitted; pass an explicit one to make retries safe.",
+        ),
     },
     async ({ idempotencyKey, ...body }) => {
       const idem = idempotencyKey ?? randomUUID();
@@ -183,7 +185,7 @@ export function registerTransactionTools(server: McpServer, client: MercuryClien
       "",
       "DO NOT USE: when you intend to transfer between your own accounts (use `mercury_create_internal_transfer` — no external recipient). For payments that may execute immediately under workspace policy, use `mercury_send_money` (different surface).",
       "",
-      "SIDE EFFECTS: creates a **pending approval request** on Mercury — no money has moved at this point. A human approver must sign off in the Mercury web/mobile app. Once approved, Mercury executes the underlying ACH / wire / check. **Idempotent via `idempotencyKey`** — auto-generated if not passed. Audit log entry on Mercury for the request itself.",
+      "SIDE EFFECTS: creates a **pending approval request** on Mercury — no money has moved at this point. A human approver must sign off in the Mercury web/mobile app. Once approved, Mercury executes the underlying ACH / wire / check. **Idempotent via `idempotencyKey`** — auto-generated if not passed; pass an explicit one to make retries safe. Audit log entry on Mercury for the request itself.",
       "",
       'RETURNS: `{ id, status: "pendingApproval", amount, ... }` — track via `mercury_get_transaction` once executed.',
     ].join("\n"),
@@ -194,7 +196,12 @@ export function registerTransactionTools(server: McpServer, client: MercuryClien
       paymentMethod: z.enum(["ach", "wire", "check"]).describe("Payment method"),
       note: z.string().optional(),
       externalMemo: z.string().optional(),
-      idempotencyKey: z.string().optional(),
+      idempotencyKey: z
+        .string()
+        .optional()
+        .describe(
+          "Unique key to prevent duplicate transfers. Auto-generated if omitted; pass an explicit one to make retries safe.",
+        ),
     },
     async ({ accountId, idempotencyKey, ...body }) => {
       const idem = idempotencyKey ?? randomUUID();

--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -90,7 +90,7 @@ export function registerTransactionTools(server: McpServer, client: MercuryClien
         .string()
         .optional()
         .describe(
-          "Unique key to prevent duplicate transfers. If not provided, a UUID is generated.",
+          "Unique key to prevent duplicate transfers. Auto-generated if omitted; pass an explicit one to make retries safe.",
         ),
     },
     async ({ accountId, idempotencyKey, ...body }) => {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,4 +1,4 @@
-import { MercuryClient, MercuryError } from "../src/client.js";
+import { MercuryClient, MercuryError, MERCURY_ERROR_MESSAGE_MAX } from "../src/client.js";
 
 const ORIGINAL_FETCH = global.fetch;
 
@@ -149,5 +149,34 @@ describe("MercuryError", () => {
   it("body remains accessible on the property for callers that need it", () => {
     const err = new MercuryError("boom", 400, { field: "amount", reason: "missing" });
     expect(err.body).toEqual({ field: "amount", reason: "missing" });
+  });
+
+  it("preserves messages at or below the byte cap unchanged", () => {
+    const justBelow = "x".repeat(MERCURY_ERROR_MESSAGE_MAX);
+    const err = new MercuryError(justBelow, 400);
+    expect(err.message).toBe(justBelow);
+    expect(err.message).not.toContain("[truncated]");
+  });
+
+  it("caps over-budget messages with a truncation marker (head + tail)", () => {
+    const oversized = "A".repeat(2000) + "MIDDLE-PADDING".repeat(500) + "B".repeat(2000);
+    const err = new MercuryError(oversized, 400);
+    // Net length is bounded — generous upper bound for the marker.
+    expect(err.message.length).toBeLessThanOrEqual(MERCURY_ERROR_MESSAGE_MAX + 64);
+    // Both ends are preserved so a reader still sees opening and
+    // closing context of the upstream payload.
+    expect(err.message.startsWith("A")).toBe(true);
+    expect(err.message.endsWith("B")).toBe(true);
+    expect(err.message).toContain("[truncated]");
+    // The middle padding must be gone — that's the whole point.
+    expect(err.message).not.toContain("MIDDLE-PADDING");
+  });
+
+  it("caps from the source so toString/toJSON consumers see the bounded value", () => {
+    const oversized = "Z".repeat(MERCURY_ERROR_MESSAGE_MAX * 4);
+    const err = new MercuryError(oversized, 500, { secret: "leak" });
+    expect(err.message.length).toBeLessThan(oversized.length);
+    expect(err.toString()).toContain("[truncated]");
+    expect((err.toJSON() as { message: string }).message).toContain("[truncated]");
   });
 });

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -18,6 +18,7 @@ import {
   readFileSync,
   rmSync,
   statSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -240,6 +241,34 @@ describe("Middleware", () => {
         chmodSync(stateDir, 0o700);
       }
       expect(errSpy).toHaveBeenCalledWith(expect.stringMatching(/failed to persist state to/));
+    });
+
+    it("releases the lockfile after a successful enforce", () => {
+      enforceRateLimit("mercury_send_money");
+      // The lockfile lives next to ratelimit.json; once enforce
+      // returns, no lock should remain.
+      expect(() => statSync(join(stateDir, "ratelimit.json.lock"))).toThrow();
+    });
+
+    it("releases the lockfile after a denied enforce (RateLimitError)", () => {
+      process.env.MERCURY_MCP_RATE_LIMIT_payments = "1/day,5/month";
+      enforceRateLimit("mercury_send_money");
+      expect(() => enforceRateLimit("mercury_send_money")).toThrow(RateLimitError);
+      // Even on the throwing path the finally clause must remove the lock.
+      expect(() => statSync(join(stateDir, "ratelimit.json.lock"))).toThrow();
+    });
+
+    it("reclaims a stale lockfile (pre-existing, mtime older than the grace window)", () => {
+      mkdirSync(stateDir, { recursive: true });
+      const lockPath = join(stateDir, "ratelimit.json.lock");
+      writeFileSync(lockPath, "");
+      // Backdate mtime well past the 5 s stale window so the next
+      // enforce reclaims the lock instead of timing out.
+      const oneMinuteAgoMs = Date.now() - 60_000;
+      utimesSync(lockPath, oneMinuteAgoMs / 1000, oneMinuteAgoMs / 1000);
+      expect(() => enforceRateLimit("mercury_send_money")).not.toThrow();
+      // After reclaim + release, the lockfile is gone again.
+      expect(() => statSync(lockPath)).toThrow();
     });
   });
 
@@ -486,6 +515,80 @@ describe("Middleware", () => {
         expect.stringContaining("failed to write"),
         expect.any(String),
       );
+    });
+
+    it("pre-creates the audit-log parent dir at mode 0o700", () => {
+      const nestedDir = join(tmpDir, "nested-audit");
+      const nestedAudit = join(nestedDir, "audit.log");
+      process.env.MERCURY_MCP_AUDIT_LOG = nestedAudit;
+      logAudit("mercury_send_money", { amount: 1 }, "ok");
+      expect(statSync(nestedDir).mode & 0o777).toBe(0o700);
+      expect(readFileSync(nestedAudit, "utf8")).toContain("mercury_send_money");
+    });
+
+    it("does not narrow the mode of a pre-existing parent dir", () => {
+      // mkdir { mode: 0o700 } only applies the mode to dirs the call
+      // creates. A pre-existing 0o755 dir keeps its original mode.
+      chmodSync(tmpDir, 0o755);
+      process.env.MERCURY_MCP_AUDIT_LOG = auditPath;
+      try {
+        logAudit("mercury_send_money", {}, "ok");
+        expect(statSync(tmpDir).mode & 0o777).toBe(0o755);
+      } finally {
+        chmodSync(tmpDir, 0o700);
+      }
+    });
+
+    it("rotates the audit log to .1 once it exceeds the byte cap", () => {
+      process.env.MERCURY_MCP_AUDIT_LOG = auditPath;
+      process.env.MERCURY_MCP_AUDIT_LOG_MAX_BYTES = "200";
+      try {
+        // Write enough entries to push the live log past 200 bytes.
+        for (let i = 0; i < 5; i++) {
+          logAudit("mercury_send_money", { padding: "x".repeat(80), seq: i }, "ok");
+        }
+        // After enough writes, .1 must exist and the live log must be
+        // smaller than the cumulative content.
+        expect(statSync(`${auditPath}.1`).size).toBeGreaterThan(0);
+        expect(statSync(auditPath).size).toBeGreaterThan(0);
+      } finally {
+        delete process.env.MERCURY_MCP_AUDIT_LOG_MAX_BYTES;
+      }
+    });
+
+    it("overwrites .1 on a second rotation (single-generation chain)", () => {
+      process.env.MERCURY_MCP_AUDIT_LOG = auditPath;
+      process.env.MERCURY_MCP_AUDIT_LOG_MAX_BYTES = "200";
+      try {
+        for (let i = 0; i < 5; i++) {
+          logAudit("mercury_send_money", { padding: "x".repeat(80), seq: i }, "ok");
+        }
+        const firstRotationContent = readFileSync(`${auditPath}.1`, "utf8");
+        for (let i = 5; i < 10; i++) {
+          logAudit("mercury_send_money", { padding: "y".repeat(80), seq: i }, "ok");
+        }
+        const secondRotationContent = readFileSync(`${auditPath}.1`, "utf8");
+        // The second rotation overwrites .1 — old "x" payload is gone.
+        expect(secondRotationContent).not.toBe(firstRotationContent);
+      } finally {
+        delete process.env.MERCURY_MCP_AUDIT_LOG_MAX_BYTES;
+      }
+    });
+
+    it("falls back to default cap when MERCURY_MCP_AUDIT_LOG_MAX_BYTES is malformed", () => {
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      process.env.MERCURY_MCP_AUDIT_LOG = auditPath;
+      process.env.MERCURY_MCP_AUDIT_LOG_MAX_BYTES = "not-a-number";
+      try {
+        // Default cap is 50 MB, far above one tiny entry — no rotation.
+        logAudit("mercury_send_money", { ok: true }, "ok");
+        expect(() => statSync(`${auditPath}.1`)).toThrow();
+        expect(errSpy).toHaveBeenCalledWith(
+          expect.stringContaining("invalid MERCURY_MCP_AUDIT_LOG_MAX_BYTES"),
+        );
+      } finally {
+        delete process.env.MERCURY_MCP_AUDIT_LOG_MAX_BYTES;
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes the 6 LOW/INFO findings from the v0.12.0 security review (`klodr/mercury-invoicing-mcp` report). The single MEDIUM (`MERCURY_API_BASE_URL` validation) is handled separately in PR #98.

### LOW

- **Audit-log dir not pre-created at `0o700`** (`src/middleware.ts:309` vs `:174`) — mirrors the state-file pattern; the log no longer sits inside a world-readable directory on a multi-tenant host. Mode is only applied to dirs the call creates, so a pre-existing parent keeps its original mode.
- **`MercuryError.message` carries upstream bytes** — caps the message at 2 KB at the source (constructor) with a structured head/tail truncation (`... [truncated] ...`) so both ends of the upstream payload remain visible. Bounds context-window saturation; the existing fence + `stripControl` stack stays unchanged.
- **Rate-limit RMW not file-locked** — wraps the load → check → append → persist cycle in an O_EXCL lockfile sibling to `ratelimit.json`. Stale locks are reclaimed after a 5 s grace window; sustained contention beyond a 2 s timeout falls through with a warning rather than blocking the tool call. `Atomics.wait` on a tiny SharedArrayBuffer keeps the retry sync without burning CPU. No new dependency.

### INFO

- **Idempotency docs** — clarify `mercury_request_send_money` and `mercury_create_internal_transfer` to match `mercury_send_money` (`"auto-generated if omitted; pass an explicit one to make retries safe"`). No code change to the call path.
- **Audit-log rotation** — adds `MERCURY_MCP_AUDIT_LOG_MAX_BYTES` (default 50 MB). Single-generation rename (`<path>` -> `<path>.1`) before the next append. Operators who want a longer chain still compose with their own `logrotate`. Documented in `.github/SECURITY.md`.
- **`socket.yml` annual review** — adds a `# REVIEW BY 2027-04` marker above the `issueRules` block so the next audit catches whether the suppressions remain justified.

Reuses the existing test infrastructure (no new test deps).

## Test plan

- [x] `npm test` — 194 passing (+11 new: audit dir mode, dir non-narrowing, rotation behaviour, second rotation overwrites `.1`, malformed env-var fallback, message cap with both ends preserved, lock release on success, lock release on `RateLimitError`, stale-lock reclaim, message cap visible through `toString`/`toJSON`)
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] Commit signed (ED25519)
- [x] No conflict with PR #98 (`src/server.ts`, `test/server.test.ts` untouched)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit logs now rotate automatically when exceeding size limits (configurable, default 50MB)
  * Error messages are capped at 2048 characters to prevent oversized outputs

* **Improvements**
  * Rate limiting enhanced with better inter-process coordination for concurrent operations

* **Documentation**
  * Updated transaction retry safety guidance for idempotency keys
  * Enhanced security documentation on audit logging and persistence behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->