### PR TITLE
chore(deps): bump zod 4.3.6 → 4.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "ipaddr.js": "^2.3.0",
         "us-bank-account-validator": "^1.1.0",
-        "zod": "^4.3.6"
+        "zod": "^4.4.2"
       },
       "bin": {
         "mercury-invoicing-mcp": "dist/index.js"
@@ -5130,9 +5130,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.2.tgz",
+      "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ipaddr.js": "^2.3.0",
     "us-bank-account-validator": "^1.1.0",
-    "zod": "^4.3.6"
+    "zod": "^4.4.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary

Pre-empts the weekly dependabot run (Monday 2026-05-04) which would otherwise open the same bump grouped under `production-dependencies`.

- `zod` 4.3.6 → 4.4.2 (minor — `zod` schemas drive every tool input/output in this repo, so isolated on its own PR for independent triage if anything regresses)

The companion `dev-dependencies` bump is on PR #102.

## Test plan

- [x] `npm test` — 227/227 green against zod 4.4.2
- [x] `npm run build` clean (101 KB ESM bundle, identical to baseline)
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [ ] CodeRabbit + Qodo (DeepSeek + Gemini) reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `zod` dependency to version 4.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->