### PR TITLE
chore(release): v0.14.0 — dependency refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-05-03 — Dependency refresh
+
+### Changed
+
+- **`zod`** 4.3.6 → 4.4.2 (production). Schemas drive every tool input/output in this repo; bumped on its own PR (#103) for independent triage. Tests 227/227 pass against the new minor.
+- **`eslint`** 10.2.1 → 10.3.0 (dev, minor).
+- **`typescript-eslint`** 8.59.0 → 8.59.1 (dev, patch).
+
+Pre-empts the weekly dependabot run rather than letting it open the bumps over multiple cycles. Two PRs: dev-deps (#102) and prod-deps (#103).
+
 ## [0.13.0] - 2026-04-26 — Layered SSRF defense + MCP annotations + LOW/INFO security findings
 
 A minor release shipping three independently-developed lines of work
@@ -566,7 +576,8 @@ This release supersedes **all** prior 0.x versions of `mercury-invoicing-mcp`. T
 - Smithery + Official MCP Registry manifests
 - Examples and publishing checklist
 
-[Unreleased]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/klodr/mercury-invoicing-mcp/compare/v0.10.0...v0.11.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mercury-invoicing-mcp",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-invoicing-mcp",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/mercury-invoicing-mcp",
   "description": "Mercury Banking MCP server with full Invoicing API support — accounts, transactions, recipients, customers, invoices (one-shot + recurring), webhooks.",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "repository": {
     "url": "https://github.com/klodr/mercury-invoicing-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "mercury-invoicing-mcp",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,7 @@ import { registerAllPrompts } from "./prompts/index.js";
 // Kept in sync with package.json by scripts/sync-version.mjs (called by the
 // `npm version` lifecycle hook). Do not edit manually — bump via
 // `npm version patch|minor|major`.
-export const VERSION = "0.13.0";
+export const VERSION = "0.14.0";
 export const SANDBOX_BASE_URL = "https://api-sandbox.mercury.com/api/v1";
 
 // Strict allowlist of Mercury hostnames `validateBaseUrl()` accepts without


### PR DESCRIPTION
## Summary

Bumps version to **0.14.0** across `package.json`, `server.json`, `src/server.ts:VERSION`, `package-lock.json`. Converts `CHANGELOG.md` `[Unreleased]` to `[0.14.0] - 2026-05-03`.

Pure dependency-refresh release on top of 0.13.0 — no API surface changes.

## Bumps already in main

| Package | From | To | Notes |
|---|---|---|---|
| `zod` | 4.3.6 | 4.4.2 | prod, minor — schemas pervasive in this repo |
| `eslint` | 10.2.1 | 10.3.0 | dev, minor |
| `typescript-eslint` | 8.59.0 | 8.59.1 | dev, patch |

## Test plan

- [x] `npm test` — 227/227 green
- [x] `npm run build` clean (101 KB ESM bundle)
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [ ] CodeRabbit + Qodo (DeepSeek + Gemini) reviews
- [ ] Post-merge: tag `v0.14.0` from `main` HEAD signed, push tag → release workflow auto-publishes to npm with provenance