### PR TITLE
ci: enable codecov OIDC upload for Dependabot context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,15 @@ jobs:
   build:
     name: Build & Test (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    # `id-token: write` lets codecov-action upload coverage via OIDC
+    # without a long-lived `CODECOV_TOKEN` secret. This matters for
+    # Dependabot PRs in particular: Dependabot's restricted secret
+    # context cannot read `CODECOV_TOKEN`, so without OIDC the upload
+    # silently fails, codecov never posts the required status check,
+    # and the merge gate stays BLOCKED for every dependency PR.
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -68,7 +77,11 @@ jobs:
         with:
           fail_ci_if_error: false
           slug: klodr/mercury-invoicing-mcp
-          token: ${{ secrets.CODECOV_TOKEN }}
+          # OIDC-based upload — works in Dependabot PR context too,
+          # where `secrets.CODECOV_TOKEN` is unavailable. Tokens are
+          # still scoped per-upload; OIDC just removes the long-lived
+          # secret from the round-trip.
+          use_oidc: true
 
       - name: Upload test results to Codecov (Test Analytics)
         if: ${{ always() && matrix.node == '22' && !cancelled() }}
@@ -78,4 +91,4 @@ jobs:
           files: ./test-results.junit.xml
           fail_ci_if_error: false
           slug: klodr/mercury-invoicing-mcp
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true


### PR DESCRIPTION
## Summary

Enables OIDC-based codecov upload so that **Dependabot PRs** can post
the required `codecov/patch` and `codecov/project` status checks.

## The bug

Dependabot's workflow context cannot read regular Actions secrets like
`CODECOV_TOKEN`. The codecov-action step runs with an empty token,
fails silently (`fail_ci_if_error: false`), no coverage upload reaches
codecov, no status posts → the merge gate stays `BLOCKED` for every
dependency PR.

7 dependency PRs are stuck on this right now (3 on mercury, 4 on
faxdrop), all CI-green and CodeRabbit-approved.

## The fix

- Job-level `permissions: { contents: read, id-token: write }`
- `use_oidc: true` on both codecov-action invocations
- Drops the `token: ${{ secrets.CODECOV_TOKEN }}` line that no longer
  has a value to work with

OIDC works in both Dependabot and regular PR contexts — GitHub mints
a per-job JWT at runtime that codecov accepts in lieu of a long-lived
secret.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: rebase one stuck Dependabot PR onto main, confirm
      `codecov/patch` and `codecov/project` statuses post (success
      via `if_no_uploads: success` if no source change, normal
      coverage delta otherwise)
- [ ] Confirm merge gate clears `BLOCKED` once those statuses arrive

## Bootstrap caveat

This PR's own diff is also `.github/**`-only (covered by codecov.yml
`ignore`), so it will hit the same blocker on first push.
**Maintainer admin merge** unblocks the cycle once CR + reviewer
approve; subsequent dependency PRs unblock naturally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration for automated testing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->