### PR TITLE
ci: add workflow_dispatch trigger to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,7 @@ name: release-please
 on:
   push:
     branches: [main]
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` trigger to `release-please.yml` so the workflow can be re-run manually when the auto-generated release PR ends up in a stuck state (typically `DIRTY` after a force-push on main).

## Why

After a remediation force-push on main, the open release PR can fall out of sync with main and become unmergeable on its CHANGELOG. With `workflow_dispatch` available, the maintainer can re-run release-please on demand to regenerate that PR cleanly, instead of resolving the conflict by hand.

## Test plan

- Merge this PR
- From Actions → release-please → Run workflow on `main`
- Confirm release-please updates the open release PR (or opens a fresh one)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to support manual triggering in addition to automatic triggering on main branch updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->