### PR TITLE
ci: backport editorconfig/gitleaks/lockfile-lint/osv-scanner

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig — keeps editor-induced whitespace differences out of
+# diffs across whatever IDE / OS contributors use.
+# https://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+# Markdown is whitespace-sensitive (trailing spaces = hard line break,
+# tables align by column). Don't auto-strip trailing whitespace.
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -36,7 +36,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node 22
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -1,0 +1,68 @@
+name: Bundle Analysis
+
+# Codecov Bundle Analysis. Tracks the size of `dist/index.js` (the
+# tsup/esbuild ESM output we publish to npm) over time so a PR that
+# accidentally adds a heavy dependency or stops tree-shaking surfaces
+# in the Codecov "Bundles" tab. Read-only on this repo's permissions
+# beyond contents:read; the upload uses the SAME `CODECOV_TOKEN`
+# secret the coverage upload in `ci.yml` already consumes — Codecov's
+# repo upload token is feature-agnostic (covers coverage, bundle
+# analysis, and test analytics from a single secret), so no new
+# secret to provision.
+
+on:
+  push:
+    branches: [main]
+    # Also snapshot on every release tag (`v*`) so the Codecov
+    # "Bundles" tab carries a labelled entry per release alongside
+    # the per-commit history from main / PRs.
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bundle-analysis:
+    name: Bundle Analysis
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+
+      - name: Setup Node 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload bundle stats to Codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        # Skip silently if the secret is not provisioned yet rather
+        # than failing CI on unrelated PRs (e.g. a Dependabot PR
+        # before the secret is shared with bot context). Reading
+        # `secrets.*` directly inside `if:` would expose the secret's
+        # existence to the workflow log; piping through `env` and
+        # checking inside the script keeps the secret state opaque.
+        run: |
+          if [ -z "$CODECOV_TOKEN" ]; then
+            echo "CODECOV_TOKEN not configured — skipping Codecov upload."
+            exit 0
+          fi
+          npx @codecov/bundle-analyzer dist \
+            --upload-token "$CODECOV_TOKEN" \
+            --bundle-name mercury-invoicing-mcp

--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -23,6 +23,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write   # OIDC tokenless upload to Codecov
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -49,23 +50,13 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Upload bundle stats to Codecov
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        # Skip silently if the secret is not provisioned yet rather
-        # than failing CI on unrelated PRs (e.g. a Dependabot PR
-        # before the secret is shared with bot context). Reading
-        # `secrets.*` directly inside `if:` would expose the secret's
-        # existence to the workflow log; piping through `env` and
-        # checking inside the script keeps the secret state opaque.
+      - name: Upload bundle stats to Codecov (OIDC, tokenless)
+        # OIDC tokenless upload — the job claims `id-token: write` above,
+        # codecov auto-detects GitHub Actions and exchanges the OIDC token
+        # for an upload credential. Aligned with ci.yml's coverage upload.
+        # Pinned version: a floating `npx @codecov/bundle-analyzer` would
+        # bypass package-lock determinism and pull whatever is published at
+        # CI time. The chosen version is bumped via Dependabot's npm group.
         run: |
-          if [ -z "$CODECOV_TOKEN" ]; then
-            echo "CODECOV_TOKEN not configured — skipping Codecov upload."
-            exit 0
-          fi
-          # Pinned version: a floating `npx @codecov/bundle-analyzer` would
-          # bypass package-lock determinism and pull whatever is published at
-          # CI time. The chosen version is bumped via Dependabot's npm group.
           npx @codecov/bundle-analyzer@2.0.1 dist \
-            --upload-token "$CODECOV_TOKEN" \
             --bundle-name mercury-invoicing-mcp

--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -63,6 +63,9 @@ jobs:
             echo "CODECOV_TOKEN not configured — skipping Codecov upload."
             exit 0
           fi
-          npx @codecov/bundle-analyzer dist \
+          # Pinned version: a floating `npx @codecov/bundle-analyzer` would
+          # bypass package-lock determinism and pull whatever is published at
+          # CI time. The chosen version is bumped via Dependabot's npm group.
+          npx @codecov/bundle-analyzer@2.0.1 dist \
             --upload-token "$CODECOV_TOKEN" \
             --bundle-name mercury-invoicing-mcp

--- a/.github/workflows/editorconfig-check.yml
+++ b/.github/workflows/editorconfig-check.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: editorconfig-checker
         uses: editorconfig-checker/action-editorconfig-checker@840e866d93b8e032123c23bac69dece044d4d84c # v2.2.0

--- a/.github/workflows/editorconfig-check.yml
+++ b/.github/workflows/editorconfig-check.yml
@@ -1,0 +1,30 @@
+name: EditorConfig check
+
+# Enforces the rules in `.editorconfig` (UTF-8, LF line endings,
+# 2-space indent, no trailing whitespace except in Markdown). Cheap
+# CI gate that catches editor-induced whitespace drift before review.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  editorconfig-check:
+    name: EditorConfig check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+
+      - name: editorconfig-checker
+        uses: editorconfig-checker/action-editorconfig-checker@840e866d93b8e032123c23bac69dece044d4d84c # v2.2.0

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,43 @@
+name: Gitleaks (secret scanning)
+
+# Scans every push and PR for accidentally-committed secrets (API
+# keys, tokens, certificates, .env files). Free OSS scanner under
+# the standard MIT license.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
+  schedule:
+    - cron: "0 5 * * 1"
+
+permissions:
+  contents: read
+  # gitleaks-action queries /repos/.../pulls/<n>/commits to enumerate
+  # the PR's commit list. Without `pull-requests: read` the API call
+  # 403s and the whole job exits with "Resource not accessible by
+  # integration" — purely a permission grant, no secret involved.
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        with:
+          # Full history needed so gitleaks can audit every commit on
+          # PR branches, not just the head.
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Full history needed so gitleaks can audit every commit on
           # PR branches, not just the head.

--- a/.github/workflows/lockfile-lint.yml
+++ b/.github/workflows/lockfile-lint.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node 22
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -57,5 +57,4 @@ jobs:
             --validate-https \
             --allowed-hosts npm \
             --validate-package-names \
-            --validate-checksum \
             --validate-integrity

--- a/.github/workflows/lockfile-lint.yml
+++ b/.github/workflows/lockfile-lint.yml
@@ -1,0 +1,57 @@
+name: Lockfile lint
+
+# Anti supply-chain check: every URL in `package-lock.json` must point
+# to the official npm registry. Catches a malicious `resolved:` host
+# slipping in via a hand-crafted lockfile commit (e.g. compromised
+# contributor / typo-squatted registry mirror) before npm install ever
+# runs.
+#
+# Also gates `integrity` (every entry must carry a SRI hash) and the
+# allowed protocol set.
+
+on:
+  # No paths-filter: this workflow MUST run on every push/PR even
+  # when nothing in the lockfile changed, otherwise listing it as a
+  # required status check in the main ruleset would block every
+  # non-lockfile-touching PR forever (the check would never report).
+  # Cost is ~10s — negligible. The trade-off: an extra run per PR
+  # in exchange for a check that always reports.
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lockfile-lint:
+    name: Lockfile lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+
+      - name: Setup Node 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
+      - name: Install lockfile-lint
+        run: npm install -g lockfile-lint@4.14.1
+
+      - name: Validate package-lock.json
+        run: |
+          lockfile-lint \
+            --path package-lock.json \
+            --type npm \
+            --validate-https \
+            --allowed-hosts npm \
+            --validate-package-names \
+            --validate-checksum \
+            --validate-integrity

--- a/.github/workflows/lockfile-lint.yml
+++ b/.github/workflows/lockfile-lint.yml
@@ -43,6 +43,10 @@ jobs:
           node-version: "22"
 
       - name: Install lockfile-lint
+        env:
+          # Disable lifecycle scripts during the global install — defense-
+          # in-depth against a transitive postinstall trying to side-load.
+          NPM_CONFIG_IGNORE_SCRIPTS: "true"
         run: npm install -g lockfile-lint@4.14.1
 
       - name: Validate package-lock.json

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install OSV-Scanner CLI (pinned binary, sha256-verified)
         # Pinned to v2.3.6. The SHA256 below is the upstream-published
@@ -63,4 +63,6 @@ jobs:
         # skips it).
         run: |
           set -euo pipefail
-          ./osv-scanner --recursive --format=table ./
+          # v2 CLI uses subcommands — `scan source` performs the
+          # source-tree scan that v1's bare invocation did.
+          ./osv-scanner scan source --recursive --format=table ./

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,66 @@
+name: OSV-Scanner
+
+# Google's OSS vulnerability scanner. Cross-references every dependency
+# in package-lock.json against the OSV.dev database (which aggregates
+# GitHub Security Advisories, npm advisories, RustSec, Go vulndb, PyPI,
+# etc.) and fails the build if a vulnerable version is found. We run
+# the OSV-Scanner CLI directly and surface findings via the workflow
+# log + non-zero exit code (which blocks the merge via the
+# required-status-checks ruleset).
+#
+# Reference: https://google.github.io/osv-scanner/
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
+  schedule:
+    - cron: "0 7 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  osv-scanner:
+    name: OSV-Scanner
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+
+      - name: Install OSV-Scanner CLI (pinned binary, sha256-verified)
+        # Pinned to v2.3.6. The SHA256 below is the upstream-published
+        # sha256sum from osv-scanner_SHA256SUMS at the same release tag
+        # — verifying it before chmod prevents a tampered binary from
+        # ever running.
+        env:
+          OSV_SCANNER_VERSION: "v2.3.6"
+          OSV_SCANNER_SHA256: "f689e183ef0d573d2459738aae457d411a26241ae58b5088de1af288b3355604"
+        run: |
+          set -euo pipefail
+          curl --fail --show-error --silent --location \
+               --retry 3 --retry-all-errors \
+               --connect-timeout 10 --max-time 120 \
+               -o osv-scanner \
+               "https://github.com/google/osv-scanner/releases/download/${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64"
+          echo "${OSV_SCANNER_SHA256}  osv-scanner" | sha256sum --check --strict
+          chmod +x osv-scanner
+
+      - name: Scan dependencies (fail on findings)
+        # --recursive walks every nested manifest (none today, but
+        # future-proof).
+        # --format=table renders a human-readable report in the log.
+        # Non-zero exit on any finding fails the workflow → blocks
+        # merge through the required-status-checks ruleset.
+        # NB: v2.x of the CLI dropped `--skip-git` (git history scan
+        # is opt-in via `--commit` instead, so the default already
+        # skips it).
+        run: |
+          set -euo pipefail
+          ./osv-scanner --recursive --format=table ./


### PR DESCRIPTION
## Summary

Backports CI hardening workflows from another klodr/* MCP that already runs them, so this repo gets the same baseline coverage:

- **`.editorconfig`** + **`editorconfig-check.yml`** — UTF-8 / LF / 2-space / no trailing whitespace, enforced in CI.
- **`gitleaks.yml`** — secret scanning on every push + PR + weekly schedule.
- **`lockfile-lint.yml`** — anti supply-chain: every `package-lock.json` URL must point to the official npm registry, every entry must carry a SRI hash.
- **`osv-scanner.yml`** — Google OSV vulnerability scanner CLI (pinned + sha256-verified) cross-referencing every dep against OSV.dev.

(Bundle Analysis is also added on the repos that did not already have it.)

All workflow actions are SHA-pinned. No new secrets required (Codecov token already provisioned for the coverage upload is reused for bundle analysis when relevant).

## Test plan

- Merge → confirm each new workflow runs green on a follow-up commit
- Once stable, add the new check names to the `main` ruleset's `required_status_checks`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added repository-wide editor configuration to enforce consistent encoding, line endings, indentation, and whitespace handling.
  * Strengthened CI with automated checks for bundle analysis, editorconfig validation, secret scanning, lockfile integrity, and dependency vulnerability scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->