### PR TITLE
ci(bundle-analysis): add codecov-bundle.json for OIDC upload

### DIFF
--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -23,7 +23,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write   # OIDC tokenless upload to Codecov
+  id-token: write # OIDC tokenless upload to Codecov
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -59,4 +59,5 @@ jobs:
         # CI time. The chosen version is bumped via Dependabot's npm group.
         run: |
           npx @codecov/bundle-analyzer@2.0.1 dist \
+            --config-file=codecov-bundle.json \
             --bundle-name mercury-invoicing-mcp

--- a/codecov-bundle.json
+++ b/codecov-bundle.json
@@ -1,0 +1,5 @@
+{
+  "oidc": {
+    "useGitHubOIDC": true
+  }
+}


### PR DESCRIPTION
## Summary

Adds `codecov-bundle.json` so the bundle-analyzer CLI can exchange GitHub Actions OIDC for the codecov upload credential. Without this file the analyzer falls back to auto-detection, which currently 400s from codecov; explicit OIDC config makes the upload work in Dependabot context too.

## Test plan

- Merge → confirm Bundle Analysis run goes green on the next push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced bundle analysis workflow configuration to streamline code quality checks and artifact processing in the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->