### PR TITLE
ci(codecov): make only_pulls: false explicit

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,7 @@ coverage:
       default:
         target: auto
         threshold: 0.5%
+        only_pulls: false
         # Project coverage shouldn't drop more than 0.5% in any single PR.
         if_no_uploads: success
         if_not_found: success
@@ -14,6 +15,7 @@ coverage:
       default:
         target: 95%
         threshold: 1.5%
+        only_pulls: false
         if_no_uploads: success
         if_not_found: success
         # Strict patch gate (95% target, 1.5% threshold) — new code must


### PR DESCRIPTION
Adds explicit `only_pulls: false` to the project + patch defaults to match gmail/relayfi where the flag is already explicit. Same effective behaviour as before (false is the codecov default) — purely cohérence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration settings to ensure consistent reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->