### PR TITLE
ci(codecov): strip inline comments from codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,12 +5,8 @@ coverage:
         target: auto
         threshold: 0.5%
         only_pulls: false
-        # Project coverage shouldn't drop more than 0.5% in any single PR.
         if_no_uploads: success
         if_not_found: success
-        # PRs that don't touch source code (CI bumps, doc-only, GitHub
-        # Actions updates) produce no coverage upload — pass instead of
-        # blocking on a missing report.
     patch:
       default:
         target: 95%
@@ -18,14 +14,6 @@ coverage:
         only_pulls: false
         if_no_uploads: success
         if_not_found: success
-        # Strict patch gate (95% target, 1.5% threshold) — new code must
-        # be ≥93.5% covered. The 1.5% threshold (vs an absolute 95%
-        # requirement) exists for two narrow exceptions, not a blanket
-        # relaxation:
-        # - Defensive code paths (e.g. TOCTOU re-checks, OS-level error
-        #   branches) are intentionally hard to exercise in unit tests.
-        # - Pure-formatting PRs (Prettier reflows, ESLint cleanups)
-        #   surface as "new" lines but add no logic to test.
 
 comment:
   layout: "reach,diff,flags,files,footer"


### PR DESCRIPTION
Strips inline comments from codecov.yml, keeping only the YAML config. The settings stay 100% identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration to clarify behavior when upload or report data is unavailable. Coverage gating thresholds remain unchanged at 95% target with 1.5% threshold for patch validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->