### PR TITLE
ci(release-please): mint App token instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,9 +36,23 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # Mint a short-lived GitHub App installation token. Pushing the
+      # release PR + the release tag with this token (instead of the
+      # default GITHUB_TOKEN) makes the downstream `release.yml` workflow
+      # fire automatically — GitHub blocks workflow-triggered workflows
+      # when the originating actor is the runner's GITHUB_TOKEN, but
+      # treats App-installation tokens as human-equivalent.
+      - name: Mint release-please App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - name: release-please
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
+          token: ${{ steps.app-token.outputs.token }}
           # The action reads release-please-config.json + the manifest
           # at the repo root automatically when these flags are set.
           config-file: release-please-config.json


### PR DESCRIPTION
## Summary

- Adds a step that mints a short-lived GitHub App installation token via `actions/create-github-app-token@v3.1.1`
- Passes that token to `release-please-action` instead of the default `GITHUB_TOKEN`
- Requires two secrets on this repo: `RELEASE_PLEASE_APP_ID` + `RELEASE_PLEASE_APP_PRIVATE_KEY` (already provisioned for the `klodr-release-please` App)

## Why

GitHub blocks workflow-triggered workflows when the originating actor is the runner's `GITHUB_TOKEN` (anti-loop protection). That meant every `release-please` cut needed a manual `gh workflow run release.yml --ref vX.Y.Z` to actually publish. App-installation tokens are treated as human-equivalent — downstream `release.yml` fires on the tag push automatically.

## Test plan

- [ ] Merge this PR
- [ ] Land any `fix:` / `feat:` commit on main
- [ ] Verify `release-please` opens/updates the release PR
- [ ] Merge the release PR; verify `release.yml` runs automatically (no manual dispatch)