### PR TITLE
ci(lockfile-lint): harden shape guard against null + arrays

### DIFF
--- a/.github/workflows/lockfile-lint.yml
+++ b/.github/workflows/lockfile-lint.yml
@@ -52,7 +52,14 @@ jobs:
           node --input-type=module -e '
             import { readFileSync } from "node:fs";
             const lock = JSON.parse(readFileSync("package-lock.json", "utf8"));
-            if (!lock.packages || typeof lock.packages !== "object") {
+            if (
+              !lock ||
+              typeof lock !== "object" ||
+              Array.isArray(lock) ||
+              !lock.packages ||
+              typeof lock.packages !== "object" ||
+              Array.isArray(lock.packages)
+            ) {
               console.error("package-lock.json format unsupported: missing top-level \"packages\" object (lockfile v1 or v2 without packages?). Regenerate with `npm install` on npm v7+.");
               process.exit(1);
             }


### PR DESCRIPTION
## Summary

Follow-up to the shape guard added a few minutes ago — CodeRabbit caught two gaps on faxdrop-mcp#114 ([thread](https://github.com/klodr/faxdrop-mcp/pull/114#discussion_r3212234654)):

- `lock` itself can be null → property access throws before the custom error fires.
- `typeof [] === "object"` → an array as `packages` would pass the guard and then `Object.entries` on it would yield numeric keys silently.

Reject non-object `lock`, null, and arrays at every level explicitly.

## Test plan

- [x] Local node script run against current lockfile reports `preflight OK: <N> entries`
- [ ] CI lockfile-lint workflow passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced validation checks in the dependency lock file verification process to more strictly verify lock file structure during the build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->