### PR TITLE
chore(eslint): switch to tseslint.configs.strictTypeChecked

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,7 +21,7 @@ export default tseslint.config(
     ],
   },
   js.configs.recommended,
-  ...tseslint.configs.recommendedTypeChecked,
+  ...tseslint.configs.strictTypeChecked,
   importX.flatConfigs.recommended,
   importX.flatConfigs.typescript,
   prettier,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ async function main(): Promise<void> {
   console.error(`mercury-invoicing-mcp v${VERSION} running on stdio`);
 }
 
-main().catch((error) => {
+main().catch((error: unknown) => {
   console.error("Fatal error:", error);
   process.exit(1);
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -247,7 +247,7 @@ function withRateLimitLock<T>(fn: () => T): T {
     /* fall through: openSync below will surface the real error */
   }
   const start = Date.now();
-  while (true) {
+  for (;;) {
     let fd: number | undefined;
     try {
       // O_WRONLY | O_CREAT | O_EXCL — fails with EEXIST if already held.

--- a/src/prompts/invoicing.ts
+++ b/src/prompts/invoicing.ts
@@ -35,7 +35,6 @@ const CreateCustomerArgs = {
     .max(200)
     .describe("Customer legal name (business or individual, ≤ 200 chars)."),
   email: z
-    .string()
     .email()
     .max(254)
     .describe(

--- a/src/prompts/recipes.ts
+++ b/src/prompts/recipes.ts
@@ -127,7 +127,6 @@ const CreateRecipientArgs = {
     .optional()
     .describe("Short internal nickname shown in the Mercury UI (≤ 50 chars, optional)."),
   contactEmail: z
-    .string()
     .email()
     .max(254)
     .describe(

--- a/src/server.ts
+++ b/src/server.ts
@@ -172,7 +172,11 @@ export function resolveBaseUrl(apiKey: string, explicitBaseUrl?: string): string
  * InMemoryTransport for tests).
  */
 export function createServer(opts: ServerOptions): McpServer {
-  const log = opts.log ?? ((msg: string) => console.error(msg));
+  const log =
+    opts.log ??
+    ((msg: string) => {
+      console.error(msg);
+    });
 
   const baseUrl = resolveBaseUrl(opts.apiKey, opts.baseUrl);
   if (baseUrl === SANDBOX_BASE_URL && !opts.baseUrl) {

--- a/src/tools/accounts.ts
+++ b/src/tools/accounts.ts
@@ -37,7 +37,7 @@ export function registerAccountTools(server: McpServer, client: MercuryClient): 
       "RETURNS: `{ id, name, kind, status, availableBalance, currentBalance, accountNumber, routingNumber, ... }`.",
     ].join("\n"),
     {
-      accountId: z.string().uuid().describe("The Mercury account ID"),
+      accountId: z.uuid().describe("The Mercury account ID"),
     },
     async ({ accountId }) => {
       const data = await client.get(`/account/${accountId}`);

--- a/src/tools/cards.ts
+++ b/src/tools/cards.ts
@@ -17,7 +17,7 @@ export function registerCardTools(server: McpServer, client: MercuryClient): voi
       "RETURNS: `{ cards: [{ id, last4, type, status, holderName, expiry, ... }] }`.",
     ].join("\n"),
     {
-      accountId: z.string().uuid().describe("The Mercury account ID"),
+      accountId: z.uuid().describe("The Mercury account ID"),
     },
     async ({ accountId }) => {
       const data = await client.get(`/account/${accountId}/cards`);

--- a/src/tools/credit.ts
+++ b/src/tools/credit.ts
@@ -56,7 +56,6 @@ export function registerCreditTools(server: McpServer, client: MercuryClient): v
     ].join("\n"),
     {
       accountId: z
-        .string()
         .uuid()
         .describe("The Mercury IO Credit account ID (from mercury_list_credit_accounts)"),
       limit: z

--- a/src/tools/customers.ts
+++ b/src/tools/customers.ts
@@ -31,8 +31,8 @@ export function registerCustomerTools(server: McpServer, client: MercuryClient):
     {
       limit: z.number().int().min(1).max(1000).optional().describe("Max results (1-1000)"),
       order: z.enum(["asc", "desc"]).optional(),
-      startAfter: z.string().uuid().optional().describe("Pagination cursor (forward)"),
-      endBefore: z.string().uuid().optional().describe("Pagination cursor (reverse)"),
+      startAfter: z.uuid().optional().describe("Pagination cursor (forward)"),
+      endBefore: z.uuid().optional().describe("Pagination cursor (reverse)"),
     },
     async (args) => {
       const query: Record<string, string | number | undefined> = {
@@ -60,7 +60,7 @@ export function registerCustomerTools(server: McpServer, client: MercuryClient):
       "RETURNS: `{ id, name, email, address, ... }`.",
     ].join("\n"),
     {
-      customerId: z.string().uuid().describe("Customer ID"),
+      customerId: z.uuid().describe("Customer ID"),
     },
     async ({ customerId }) => {
       const data = await client.get(`/ar/customers/${customerId}`);
@@ -85,7 +85,7 @@ export function registerCustomerTools(server: McpServer, client: MercuryClient):
     ].join("\n"),
     {
       name: z.string().describe("Customer name"),
-      email: z.string().email().describe("Customer email"),
+      email: z.email().describe("Customer email"),
       address: addressSchema.optional(),
     },
     async (args) => {
@@ -110,9 +110,9 @@ export function registerCustomerTools(server: McpServer, client: MercuryClient):
       "RETURNS: `{ id, name, email, address, ... }` — the updated customer.",
     ].join("\n"),
     {
-      customerId: z.string().uuid().describe("Customer ID"),
+      customerId: z.uuid().describe("Customer ID"),
       name: z.string().optional(),
-      email: z.string().email().optional(),
+      email: z.email().optional(),
       address: addressSchema.optional(),
     },
     async ({ customerId, ...body }) => {
@@ -137,7 +137,7 @@ export function registerCustomerTools(server: McpServer, client: MercuryClient):
       "RETURNS: confirmation payload from Mercury (`{ deleted: true, ... }` or similar).",
     ].join("\n"),
     {
-      customerId: z.string().uuid().describe("Customer ID"),
+      customerId: z.uuid().describe("Customer ID"),
     },
     async ({ customerId }) => {
       const data = await client.delete(`/ar/customers/${customerId}`);

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -39,12 +39,10 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
         .describe("Max results to return (1-1000). Default: 1000"),
       order: z.enum(["asc", "desc"]).optional().describe("Sort order. Default: asc"),
       startAfter: z
-        .string()
         .uuid()
         .optional()
         .describe("Pagination: return invoices after this ID"),
       endBefore: z
-        .string()
         .uuid()
         .optional()
         .describe("Pagination: return invoices before this ID"),
@@ -75,7 +73,7 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
       "RETURNS: `{ id, status, amount, customerId, lineItems, paymentUrl, dueDate, ... }`.",
     ].join("\n"),
     {
-      invoiceId: z.string().uuid().describe("The invoice ID (UUID)"),
+      invoiceId: z.uuid().describe("The invoice ID (UUID)"),
     },
     async ({ invoiceId }) => {
       const data = await client.get(`/ar/invoices/${invoiceId}`);
@@ -99,9 +97,8 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
       "RETURNS: `{ id, status, amount, paymentUrl, ... }` — `paymentUrl` is the Mercury-hosted page where the customer pays.",
     ].join("\n"),
     {
-      customerId: z.string().uuid().describe("Customer ID (created via mercury_create_customer)"),
+      customerId: z.uuid().describe("Customer ID (created via mercury_create_customer)"),
       destinationAccountId: z
-        .string()
         .uuid()
         .describe("Mercury account ID where invoice payments will be deposited"),
       invoiceDate: z.iso.date().describe("Invoice date (YYYY-MM-DD)"),
@@ -116,7 +113,7 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
         .boolean()
         .optional()
         .describe("Show real (vs virtual) account number on the invoice. Default: false"),
-      ccEmails: z.array(z.string().email()).optional().describe("CC emails for notifications"),
+      ccEmails: z.array(z.email()).optional().describe("CC emails for notifications"),
       sendEmailOption: z
         .enum(["DontSend", "SendNow"])
         .optional()
@@ -163,11 +160,11 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
       "RETURNS: `{ id, status, amount, ... }` — the updated invoice.",
     ].join("\n"),
     {
-      invoiceId: z.string().uuid().describe("Invoice ID"),
+      invoiceId: z.uuid().describe("Invoice ID"),
       invoiceDate: z.iso.date().optional().describe("Invoice date (YYYY-MM-DD)"),
       dueDate: z.iso.date().optional().describe("Due date (YYYY-MM-DD)"),
       lineItems: z.array(lineItemSchema).optional(),
-      ccEmails: z.array(z.string().email()).optional(),
+      ccEmails: z.array(z.email()).optional(),
       payerMemo: z.string().optional(),
       internalNote: z.string().optional(),
       poNumber: z.string().optional(),
@@ -191,6 +188,7 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
         // are elided), so the false branch is a defensive guard rather
         // than a runtime path we can hit.
         /* v8 ignore next */
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (v !== undefined) merged[k] = v;
       }
       const data = await client.post(`/ar/invoices/${invoiceId}`, merged);
@@ -218,7 +216,7 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
       'RETURNS: `{ id, status: "cancelled", ... }`.',
     ].join("\n"),
     {
-      invoiceId: z.string().uuid().describe("Invoice ID"),
+      invoiceId: z.uuid().describe("Invoice ID"),
     },
     async ({ invoiceId }) => {
       const data = await client.post(`/ar/invoices/${invoiceId}/cancel`);
@@ -240,7 +238,7 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
       "RETURNS: `{ attachments: [{ id, filename, downloadUrl, ... }] }`.",
     ].join("\n"),
     {
-      invoiceId: z.string().uuid().describe("Invoice ID"),
+      invoiceId: z.uuid().describe("Invoice ID"),
     },
     async ({ invoiceId }) => {
       const data = await client.get(`/ar/invoices/${invoiceId}/attachments`);

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -38,14 +38,8 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
         .optional()
         .describe("Max results to return (1-1000). Default: 1000"),
       order: z.enum(["asc", "desc"]).optional().describe("Sort order. Default: asc"),
-      startAfter: z
-        .uuid()
-        .optional()
-        .describe("Pagination: return invoices after this ID"),
-      endBefore: z
-        .uuid()
-        .optional()
-        .describe("Pagination: return invoices before this ID"),
+      startAfter: z.uuid().optional().describe("Pagination: return invoices after this ID"),
+      endBefore: z.uuid().optional().describe("Pagination: return invoices before this ID"),
     },
     async (args) => {
       const query: Record<string, string | number | undefined> = {

--- a/src/tools/recipients.ts
+++ b/src/tools/recipients.ts
@@ -40,11 +40,11 @@ export function registerRecipientTools(server: McpServer, client: MercuryClient)
       "RETURNS: `{ id, name, nickname, defaultPaymentMethod, ... }` — the updated recipient.",
     ].join("\n"),
     {
-      recipientId: z.string().uuid().describe("The recipient ID"),
+      recipientId: z.uuid().describe("The recipient ID"),
       name: z.string().optional().describe("Recipient legal name"),
       nickname: z.string().optional().describe("Internal nickname"),
-      contactEmail: z.string().email().optional().describe("Primary contact email"),
-      emails: z.array(z.string().email()).optional().describe("List of email addresses"),
+      contactEmail: z.email().optional().describe("Primary contact email"),
+      emails: z.array(z.email()).optional().describe("List of email addresses"),
       defaultPaymentMethod: z
         .enum(["domesticAch", "internationalWire", "domesticWire", "check"])
         .optional(),
@@ -72,7 +72,7 @@ export function registerRecipientTools(server: McpServer, client: MercuryClient)
     ].join("\n"),
     {
       name: z.string().describe("Recipient legal name"),
-      emails: z.array(z.string().email()).describe("List of email addresses"),
+      emails: z.array(z.email()).describe("List of email addresses"),
       paymentMethod: z
         .enum(["domesticAch", "internationalWire", "domesticWire", "check"])
         .describe("Payment method to send to this recipient"),

--- a/src/tools/statements.ts
+++ b/src/tools/statements.ts
@@ -17,7 +17,7 @@ export function registerStatementTools(server: McpServer, client: MercuryClient)
       "RETURNS: `{ statements: [{ id, periodStart, periodEnd, downloadUrl, ... }] }`.",
     ].join("\n"),
     {
-      accountId: z.string().uuid().describe("The Mercury account ID"),
+      accountId: z.uuid().describe("The Mercury account ID"),
       start: z.iso.date().optional().describe("Filter statements from this date (YYYY-MM-DD)"),
       end: z.iso.date().optional().describe("Filter statements to this date (YYYY-MM-DD)"),
     },

--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -18,7 +18,7 @@ export function registerTransactionTools(server: McpServer, client: MercuryClien
       "RETURNS: `{ transactions: [{ id, amount, status, postedAt, counterpartyName, ... }] }`.",
     ].join("\n"),
     {
-      accountId: z.string().uuid().describe("The Mercury account ID"),
+      accountId: z.uuid().describe("The Mercury account ID"),
       limit: z
         .number()
         .int()
@@ -55,8 +55,8 @@ export function registerTransactionTools(server: McpServer, client: MercuryClien
       "RETURNS: `{ id, amount, status, postedAt, counterpartyName, memo, ... }`.",
     ].join("\n"),
     {
-      accountId: z.string().uuid().describe("The Mercury account ID"),
-      transactionId: z.string().uuid().describe("The transaction ID"),
+      accountId: z.uuid().describe("The Mercury account ID"),
+      transactionId: z.uuid().describe("The transaction ID"),
     },
     async ({ accountId, transactionId }) => {
       const data = await client.get(`/account/${accountId}/transaction/${transactionId}`);
@@ -80,8 +80,8 @@ export function registerTransactionTools(server: McpServer, client: MercuryClien
       "RETURNS: `{ id, status, amount, ... }`. `status` reflects either immediate execution or pending-approval state, depending on workspace policy.",
     ].join("\n"),
     {
-      accountId: z.string().uuid().describe("Source Mercury account ID"),
-      recipientId: z.string().uuid().describe("Recipient ID (must already exist)"),
+      accountId: z.uuid().describe("Source Mercury account ID"),
+      recipientId: z.uuid().describe("Recipient ID (must already exist)"),
       amount: z.number().positive().describe("Amount in USD (e.g. 100.50)"),
       paymentMethod: z.enum(["ach", "wire", "check"]).describe("Payment method"),
       note: z.string().optional().describe("Internal note"),
@@ -119,14 +119,13 @@ export function registerTransactionTools(server: McpServer, client: MercuryClien
       "RETURNS: `{ id, note, categoryId, ... }` — the updated transaction.",
     ].join("\n"),
     {
-      transactionId: z.string().uuid().describe("The transaction ID"),
+      transactionId: z.uuid().describe("The transaction ID"),
       note: z
         .string()
         .nullable()
         .optional()
         .describe("Internal note (send null to clear, omit to keep current)"),
       categoryId: z
-        .string()
         .uuid()
         .nullable()
         .optional()
@@ -156,8 +155,8 @@ export function registerTransactionTools(server: McpServer, client: MercuryClien
       "RETURNS: `{ id, amount, status, ... }` — the booked transfer.",
     ].join("\n"),
     {
-      sourceAccountId: z.string().uuid().describe("Source Mercury account ID"),
-      destinationAccountId: z.string().uuid().describe("Destination Mercury account ID"),
+      sourceAccountId: z.uuid().describe("Source Mercury account ID"),
+      destinationAccountId: z.uuid().describe("Destination Mercury account ID"),
       amount: z.number().min(0.01).describe("Amount in USD (>= 0.01)"),
       note: z.string().optional().describe("Optional note attached to the transfer"),
       idempotencyKey: z
@@ -190,8 +189,8 @@ export function registerTransactionTools(server: McpServer, client: MercuryClien
       'RETURNS: `{ id, status: "pendingApproval", amount, ... }` — track via `mercury_get_transaction` once executed.',
     ].join("\n"),
     {
-      accountId: z.string().uuid().describe("Source Mercury account ID"),
-      recipientId: z.string().uuid().describe("Recipient ID"),
+      accountId: z.uuid().describe("Source Mercury account ID"),
+      recipientId: z.uuid().describe("Recipient ID"),
       amount: z.number().positive().describe("Amount in USD"),
       paymentMethod: z.enum(["ach", "wire", "check"]).describe("Payment method"),
       note: z.string().optional(),

--- a/src/tools/treasury.ts
+++ b/src/tools/treasury.ts
@@ -37,7 +37,7 @@ export function registerTreasuryTools(server: McpServer, client: MercuryClient):
       "RETURNS: `{ transactions: [{ id, amount, kind, postedAt, ... }] }`.",
     ].join("\n"),
     {
-      accountId: z.string().uuid().describe("Treasury account ID"),
+      accountId: z.uuid().describe("Treasury account ID"),
       limit: z.number().int().min(1).max(500).optional(),
       offset: z.number().int().min(0).optional(),
       start: z.iso.date().optional().describe("Filter after this date (YYYY-MM-DD)"),
@@ -63,7 +63,7 @@ export function registerTreasuryTools(server: McpServer, client: MercuryClient):
       "RETURNS: `{ statements: [{ id, periodStart, periodEnd, downloadUrl, ... }] }`.",
     ].join("\n"),
     {
-      accountId: z.string().uuid().describe("Treasury account ID"),
+      accountId: z.uuid().describe("Treasury account ID"),
     },
     async ({ accountId }) => {
       const data = await client.get(`/treasury/${accountId}/statements`);

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -33,7 +33,7 @@ Check https://docs.mercury.com/reference/webhooks for the full list.`;
  *     (transactions, invoices, balances) in clear. The
  *     `webhooks_create: 2/day` rate limit is not a real brake here —
  *     two endpoints are more than enough to exfiltrate. The old
- *     `z.string().url()` accepted `http://`, `file://`, `data:`,
+ *     `z.url()` accepted `http://`, `file://`, `data:`,
  *     `ftp://`, etc.; the description said "HTTPS" but the validator
  *     did not enforce it.
  *
@@ -46,14 +46,13 @@ Check https://docs.mercury.com/reference/webhooks for the full list.`;
  *     nothing legitimate.
  */
 const HttpsWebhookUrl = z
-  .string()
   .url()
   .refine(
     (raw) => {
       try {
         return new URL(raw).protocol === "https:";
       } catch {
-        // `z.string().url()` rejects malformed URLs before this refine
+        // `z.url()` rejects malformed URLs before this refine
         // runs, so `new URL()` cannot actually throw here. Kept
         // defensive in case the upstream validator changes.
         /* v8 ignore next */
@@ -155,7 +154,7 @@ export function registerWebhookTools(server: McpServer, client: MercuryClient): 
       "RETURNS: `{ id, url, status, events, ... }`.",
     ].join("\n"),
     {
-      webhookId: z.string().uuid().describe("The webhook endpoint ID"),
+      webhookId: z.uuid().describe("The webhook endpoint ID"),
     },
     async ({ webhookId }) => {
       const data = await client.get(`/webhooks/${webhookId}`);
@@ -206,7 +205,7 @@ export function registerWebhookTools(server: McpServer, client: MercuryClient): 
       "RETURNS: `{ id, url, status, events, ... }` — the updated webhook.",
     ].join("\n"),
     {
-      webhookId: z.string().uuid().describe("The webhook endpoint ID"),
+      webhookId: z.uuid().describe("The webhook endpoint ID"),
       url: HttpsWebhookUrl.optional().describe(
         "New publicly reachable HTTPS URL (same rules as mercury_create_webhook).",
       ),
@@ -235,7 +234,7 @@ export function registerWebhookTools(server: McpServer, client: MercuryClient): 
       "RETURNS: confirmation payload (`{ deleted: true, ... }` or similar).",
     ].join("\n"),
     {
-      webhookId: z.string().uuid().describe("The webhook endpoint ID"),
+      webhookId: z.uuid().describe("The webhook endpoint ID"),
     },
     async ({ webhookId }) => {
       const data = await client.delete(`/webhooks/${webhookId}`);


### PR DESCRIPTION
## What

Swap from `tseslint.configs.strict` to `tseslint.configs.strictTypeChecked`,
adding the type-aware rule set on top of `strict`'s syntactic rules.

## Impact (48 anomalies fixed)

- 44× `no-deprecated` — zod v4 graduated `z.string().uuid()`, `z.string().email()`, `z.string().url()` to top-level `z.uuid()`, `z.email()`, `z.url()`. Mass replacement.
- 1× `use-unknown-in-catch-callback-variable` — `(error: unknown)`
- 1× `no-confusing-void-expression` — block-bodied arrow around `console.error`
- 1× `no-unnecessary-condition` — `while (true)` → `for (;;)`
- 1× `no-unnecessary-condition` — defensive `if (v !== undefined)` after zod validation; inline disable + WHY (already had `v8 ignore`)

## Why

`strictTypeChecked` is the strongest typescript-eslint preset. The mass
zod migration is a free upgrade now that the types come from zod v4.

## Plan context

Third of four planned PRs aligning ESLint across klodr/* MCPs:
1. ✅ `eslint-plugin-promise` (#126)
2. ✅ `tseslint.configs.strict` (#127)
3. **`tseslint.configs.strictTypeChecked`** — this PR
4. `eslint-plugin-import-x`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Stricter UUID and email validation across APIs and tools for safer input handling.
  * Tighter TypeScript/linting rules for improved type-safety.
  * Slightly more robust startup error handling and default logging behavior.

* **Refactor**
  * Standardized and simplified input validation schemas and minor control-flow cleanups.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/128)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->