### PR TITLE
chore(release-please): expose chore + ci in CHANGELOG sections

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,8 +17,8 @@
     { "type": "refactor", "section": "Changed", "hidden": false },
     { "type": "revert", "section": "Fixed", "hidden": false },
     { "type": "docs", "section": "Documentation", "hidden": false },
-    { "type": "chore", "section": "Changed", "hidden": true },
-    { "type": "ci", "section": "Changed", "hidden": true },
+    { "type": "chore", "section": "Changed", "hidden": false },
+    { "type": "ci", "section": "Changed", "hidden": false },
     { "type": "test", "section": "Changed", "hidden": true },
     { "type": "build", "section": "Changed", "hidden": true }
   ],


### PR DESCRIPTION
## What

Expose `chore` and `ci` commit types in the auto-generated CHANGELOG
(previously hidden, only `feat`/`fix` were surfaced).

## Why

The recent ESLint hardening + Husky cascade landed as `chore(eslint):`
and `chore(husky):` commits — semantically correct for conventional
commits, but with `hidden: true` they vanished from the release
CHANGELOG. The 0.X.Y release built from these commits ended up listing
only the single `fix(husky):` portability follow-up, not the 5 chore
PRs that did most of the work.

`test` and `build` stay hidden — those really are internal noise.

## Effect

Future releases generated by release-please will include `chore` and
`ci` entries under "Changed" — so a reader of the CHANGELOG sees the
full set of changes, not just the bump-triggering ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog configuration to display chore and CI entries in release notes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/130)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->