### PR TITLE
ci(release-please): chain on workflow_run instead of racing CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,17 @@ name: release-please
 # Reference: https://github.com/googleapis/release-please-action
 
 on:
-  push:
+  # Wait for the workflows that produce the required-status-checks
+  # listed in the `tags` ruleset (CI → Lint & Format + Build & Test
+  # matrix, CodeQL Advanced → Analyze matrix, Docker build → Build
+  # Docker image). Triggering on `push: branches: [main]` instead
+  # would race those workflows and the GitHub Release tag-creation
+  # call would be rejected with `6 of 7 required status checks have
+  # not succeeded` because the squash commit is fresh and the checks
+  # are still pending.
+  workflow_run:
+    workflows: ["CI", "CodeQL Advanced", "Docker build"]
+    types: [completed]
     branches: [main]
   workflow_dispatch: {}
 
@@ -32,6 +42,11 @@ jobs:
   release-please:
     name: release-please
     runs-on: ubuntu-latest
+    # Skip on a workflow_run that didn't succeed — re-running release-please
+    # against a known-failed CI/Docker/CodeQL run would loop forever (the
+    # tag-creation call needs every required status check at `success`).
+    # `workflow_dispatch` invocations always pass through.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## What

Switch the `release-please` workflow trigger from `push: branches: [main]`
to `workflow_run` chained on the workflows that produce the required
status checks listed in the `tags` ruleset.

## Why

The previous trigger fired release-please **in parallel** with CI,
CodeQL, and Docker build — all on the same `push` event. release-please
then attempted to create the release tag while the other workflows were
still pending, and GitHub rejected the tag with:

```
release-please failed: Validation Failed
6 of 7 required status checks have not succeeded
```

`workflow_run` makes release-please fire **after** each upstream
workflow completes. The `if:` guard skips runs where the upstream
workflow failed (avoids retry loops on known-failed CI). The
`workflow_dispatch` trigger stays for manual re-trigger after the user
fixes a transient failure.

## Trade-off

`workflow_run` fires once per upstream workflow completion — so for
a successful main push, release-please runs N times (one per workflow
listed). It is idempotent (skips when no new commits since the last
tag), so the redundant runs are harmless but visible in the Actions
tab.

The alternative was a `wait-on-check` step (polling) inside a single
release-please run, but that costs runner time and adds a third-party
action dependency.