### PR TITLE
ci(codecov): silence GPG trust + multi-language search warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,14 @@ jobs:
       - name: Test with coverage
         run: npm run test:coverage
 
+      # Pre-mark the Codecov signing key as ultimate-trust so the
+      # subsequent `gpg --verify` inside codecov-action stops emitting
+      # "WARNING: This key is not certified with a trusted signature!".
+      # Cosmetic but misleading on a supply-chain audit log.
+      - name: Pre-trust Codecov GPG signing key
+        if: matrix.node == '22'
+        run: echo "27034E7FDB850E0BBC2C62FF806BB28AED779869:6:" | gpg --import-ownertrust
+
       - name: Upload coverage to Codecov
         if: matrix.node == '22'
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
@@ -82,6 +90,12 @@ jobs:
           # still scoped per-upload; OIDC just removes the long-lived
           # secret from the round-trip.
           use_oidc: true
+          # Point the uploader directly at vitest's lcov output and
+          # skip its multi-language search heuristics — silences the
+          # xcrun / gcov / coverage.py "not installed" warnings that
+          # are irrelevant for a Node/TypeScript project.
+          files: ./coverage/lcov.info
+          disable_search: true
 
       - name: Upload test results to Codecov (Test Analytics)
         if: ${{ always() && matrix.node == '22' && !cancelled() }}
@@ -92,3 +106,4 @@ jobs:
           fail_ci_if_error: false
           slug: klodr/mercury-invoicing-mcp
           use_oidc: true
+          disable_search: true


### PR DESCRIPTION
## What

Two cosmetic but supply-chain-misleading warnings on every CI run, both silenced.

### 1. GPG trust warning

```
gpg: Good signature from "Codecov Uploader (Codecov Uploader Verification Key) <security@codecov.io>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
```

The signature is `Good`, the fingerprint matches Codecov's official key (`27034E7F...ED779869`), the binary integrity is verified — but `gpg` flags the absence of `ownertrust` on the signing key. On a supply-chain audit log this `WARNING` line stands out as if the verification failed; it didn't.

**Fix**: pre-mark the fingerprint as `ownertrust=ultimate` *before* `codecov-action` runs its `--import` + `--verify` cycle. The verify then finds the key already ultimate-trust and the WARN line disappears. No bytes change in the verification path.

### 2. Multi-language probe noise

```
warning - xcrun is not installed or can't be found.
warning - No gcov data found.
warning - coverage.py is not installed or can't be found.
```

`codecov-cli` probes for every coverage tool it supports (Swift via `xcrun`, C/C++/Go via `gcov`, Python via `coverage.py`). Node/TypeScript on Ubuntu has none of those — the warnings are inherent to the CLI's multi-language design.

**Fix**: pass `files: ./coverage/lcov.info` + `disable_search: true`. Vitest's v8 coverage reporter writes `coverage/lcov.info`; pointing the uploader at it directly bypasses the multi-language search entirely.

## What stays

- OIDC upload, fail-on-error policies, slug pinning — unchanged.
- The Codecov GitHub Release contract (signed binary, fingerprint match, integrity check) — unchanged. Only the local trust DB gets a hint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build pipeline stability by implementing GPG key verification for coverage uploads, reducing warning messages.
  * Optimized Codecov integration configuration to streamline coverage reporting and test analytics verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/137)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->