### PR TITLE
chore: harmonize cross-repo (typecheck pre-push + fail_ci_if_error)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         if: matrix.node == '22'
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           slug: klodr/mercury-invoicing-mcp
           # OIDC-based upload — works in Dependabot PR context too,
           # where `secrets.CODECOV_TOKEN` is unavailable. Tokens are
@@ -103,7 +103,7 @@ jobs:
         with:
           report_type: test_results
           files: ./test-results.junit.xml
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           slug: klodr/mercury-invoicing-mcp
           use_oidc: true
           disable_search: true

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -73,6 +73,9 @@ npm run --silent format:check
 echo "[husky] lint..."
 npm run --silent lint
 
+echo "[husky] typecheck..."
+npm run --silent typecheck
+
 echo "[husky] tests..."
 npm run --silent test
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "test:coverage": "vitest run --coverage",
     "version": "node scripts/sync-version.mjs && git add server.json src/server.ts",
     "prepare": "husky",
-    "prepublishOnly": "NODE_ENV=production npm run build"
+    "prepublishOnly": "NODE_ENV=production npm run build",
+    "typecheck": "tsc --noEmit"
   },
   "engines": {
     "node": ">=22.22.2"

--- a/src/tools/_shared.ts
+++ b/src/tools/_shared.ts
@@ -45,5 +45,13 @@ export function defineTool<S extends ZodRawShape>(
   // (not optional) so every new tool ships with explicit semantics —
   // forgetting the annotation now fails typecheck instead of
   // silently shipping a tool with no hint set.
-  server.registerTool(name, { description, inputSchema: strictSchema, annotations }, wrapped);
+  // The MCP SDK overloads `registerTool` with shape narrowing the runtime
+  // strict-schema and the wrapped callback can't satisfy through generics.
+  // Both casts are runtime-safe — the signatures only diverge at the type
+  // level. Asserted by the existing tool-registration tests.
+  (server.registerTool as unknown as (...a: unknown[]) => unknown)(
+    name,
+    { description, inputSchema: strictSchema, annotations },
+    wrapped,
+  );
 }


### PR DESCRIPTION
## Summary

Catches up mercury-invoicing-mcp with the cross-repo harmonization baseline.

## Changes

- `src/tools/_shared.ts` — `defineTool()` registers a runtime-strict `ZodObject` via the SDK's `registerTool`, but the SDK's generic types don't surface a compatible overload. Focused double cast on the call site so TypeScript accepts the strict-schema + wrapped-handler signatures while the runtime contract stays unchanged. Hidden by the missing typecheck step.
- `package.json` — add `typecheck: tsc --noEmit` script.
- `.husky/pre-push` — add `typecheck` step between lint and tests.
- `.github/workflows/ci.yml` — align `fail_ci_if_error` to `true`.

## Cross-repo invariant

After merge, husky pre-push is byte-identical (same md5) on all 4 klodr/* MCP repos, and `npm run typecheck` is part of the pre-push gate everywhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI validation with stricter Codecov error checking for Node 22 environments
  * TypeScript type checking now runs automatically during pre-push validation
  * New typecheck command available in build scripts

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/138)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->