### PR TITLE
ci(codecov): upload v8 JSON alongside lcov for branch detail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,11 +90,13 @@ jobs:
           # still scoped per-upload; OIDC just removes the long-lived
           # secret from the round-trip.
           use_oidc: true
-          # Point the uploader directly at vitest's lcov output and
-          # skip its multi-language search heuristics — silences the
-          # xcrun / gcov / coverage.py "not installed" warnings that
-          # are irrelevant for a Node/TypeScript project.
-          files: ./coverage/lcov.info
+          # Upload BOTH the lcov rollup AND the v8-native JSON report.
+          # The JSON carries per-branch hit counts codecov needs to
+          # compute accurate indirect-changes (without it, codecov
+          # reports phantom regressions on files the PR doesn't touch).
+          # `disable_search: true` skips the multi-language probe that
+          # would otherwise warn about missing xcrun / gcov / coverage.py.
+          files: ./coverage/lcov.info,./coverage/coverage-final.json
           disable_search: true
 
       - name: Upload test results to Codecov (Test Analytics)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,13 @@ export default defineConfig({
     reporters: ["default", ["junit", { outputFile: "test-results.junit.xml" }]],
     coverage: {
       provider: "v8",
-      reporter: ["text", "lcov"],
+      // `lcov` for codecov-action's primary upload; `json` (v8 native)
+      // carries per-branch hit counts so codecov can compute accurate
+      // indirect-changes — without it codecov falls back to a coarser
+      // line-based delta and reports phantom regressions on files the
+      // PR doesn't touch. `text` keeps the human-readable summary in
+      // CI logs.
+      reporter: ["text", "lcov", "json"],
       include: ["src/**/*.ts"],
       // index.ts is the stdio entry point; testing it requires process/stdio
       // mocking that adds complexity disproportionate to its coverage value.


### PR DESCRIPTION
Backports klodr/gmail-mcp#144 fix: codecov reports phantom indirect-changes regressions when only lcov is uploaded. Adding the v8-native JSON carries per-branch hit counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code coverage reporting in the CI/CD pipeline with support for both LCOV and V8-native JSON coverage report formats.
  * Updated coverage reporting configuration to generate multiple output formats, improving compatibility with code coverage analysis tools.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/140)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->