### PR TITLE
chore: add CR title baseline (Conventional Commits + 72c cap)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -25,6 +25,12 @@ reviews:
   collapse_walkthrough: false
   abort_on_close: true
 
+  auto_title_instructions: |
+    Use Conventional Commits format: <type>[(<scope>)]: <subject>
+    Types: feat, fix, docs, chore, refactor, test, ci, build, perf, revert.
+    Scope is optional (e.g. `chore: ...` is valid).
+    Cap the entire title (including type and optional scope) at 72 characters.
+
   auto_review:
     enabled: true
     drafts: false
@@ -40,6 +46,17 @@ reviews:
       # function names like `enforceRateLimit` / `redactSensitive` are
       # self-documenting and a forced JSDoc would just paraphrase them.
       mode: off
+    title:
+      # Enforce Conventional Commits format + 72-char cap (matches the
+      # auto_title_instructions above — this is the gate that actually
+      # blocks non-conforming titles from merging).
+      mode: error
+      requirements: |
+        Conventional Commits format: <type>[(<scope>)]: <subject>.
+        Types: feat, fix, docs, chore, refactor, test, ci, build, perf, revert.
+        Scope is optional (e.g. `chore: ...` is valid without scope).
+        Subject must be in imperative mood, lowercase, no trailing period.
+        Total title length (including type/scope) must be <= 72 characters.
     # If a specific human reviewer is explicitly requested on a PR
     # (via GitHub's "Reviewers" UI), CodeRabbit's own approval must NOT
     # count as a substitute for theirs. Does not affect the common case

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,9 +26,10 @@ reviews:
   abort_on_close: true
 
   auto_title_instructions: |
-    Use Conventional Commits format: <type>[(<scope>)]: <subject>
+    Use Conventional Commits format: <type>[(<scope>)]: <subject>.
     Types: feat, fix, docs, chore, refactor, test, ci, build, perf, revert.
     Scope is optional (e.g. `chore: ...` is valid).
+    Subject must be in imperative mood, lowercase, no trailing period.
     Cap the entire title (including type and optional scope) at 72 characters.
 
   auto_review:


### PR DESCRIPTION
## Summary

Add an explicit CR title baseline (Conventional Commits format + 72-character cap) that the gmail-mcp repo already enforces. Two blocks added under `reviews:`:

- `auto_title_instructions`: tells CodeRabbit's auto-titler what shape to emit when proposing a PR title.
- `pre_merge_checks.title` (mode `error`): the actual gate that refuses non-conforming titles.

Both blocks state the cap covers the whole title (type + optional scope + subject) and that scope is optional, so `chore: ...` is valid without `(scope)`.

No code change, no behaviour change for the existing PR pipeline — just makes the title constraint explicit in CodeRabbit's config so the bot stops proposing titles that the merge gate would later refuse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration to enforce standardized pull request title formatting rules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/143)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->