### PR TITLE
ci: add auto-merge caller for release-please PRs

### DIFF
--- a/.github/workflows/auto-merge-release-please.yml
+++ b/.github/workflows/auto-merge-release-please.yml
@@ -1,0 +1,23 @@
+name: Auto-merge release-please PR
+
+# Arms `--squash --auto --delete-branch` on the perpetually-updated PR
+# opened by release-please-app[bot]. Once required CI checks go green
+# the PR self-merges, which fires release.yml downstream (signed
+# artifact + npm publish with provenance).
+#
+# Caller is intentionally minimal — the filter on the bot login and the
+# App-token mint live inside the reusable workflow on klodr/.github.
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  call:
+    uses: klodr/.github/.github/workflows/reusable-auto-merge-release-please.yml@a44b6ecf0876fde506bbf289b69a3da1efc5f5d1
+    secrets:
+      RELEASE_PLEASE_CLIENT_ID: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
+      RELEASE_PLEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/auto-merge-release-please.yml
+++ b/.github/workflows/auto-merge-release-please.yml
@@ -10,7 +10,7 @@ name: Auto-merge release-please PR
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Minimal caller for the new `klodr/.github` reusable workflow `reusable-auto-merge-release-please.yml` (pinned to commit `a44b6ec`). On `pull_request: opened`, the reusable filters for `release-please-app[bot]` author then mints an App installation token (via `client-id` + private key) and arms `gh pr merge --squash --auto --delete-branch`.

Result: the perpetual release PR self-merges as soon as branch protections + required CI go green, firing `release.yml` downstream.

## Test plan

- [ ] Caller workflow triggers on next release-please PR open
- [ ] PR self-merges once required checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated release management workflow infrastructure to improve CI/CD automation processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/147)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->