### PR TITLE
fix: scope release-please app token to least-privilege

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -98,6 +98,14 @@ jobs:
         with:
           client-id: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          # Scope the minted token to the strict set release-please needs
+          # (per googleapis/release-please-action docs). Without these,
+          # the token inherits every permission granted to the app
+          # installation — too broad for a workflow whose only job is
+          # opening release PRs and tagging releases.
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: release-please
         if: github.event_name == 'workflow_dispatch' || steps.checks-gate.outputs.ready == 'true'


### PR DESCRIPTION
## Summary

Matches the standardization applied on `klodr/gmail-mcp` (commit `e1d3239`). Adds explicit `permission-contents: write`, `permission-issues: write`, `permission-pull-requests: write` to the `actions/create-github-app-token` step so the minted token doesn't inherit every permission granted to the App installation — only what release-please actually needs.

No runtime behavior change (release-please already uses these three permissions).

## Test plan

- [ ] CI green
- [ ] CodeRabbit review APPROVED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflow permissions have been constrained to explicitly require write access only to contents, issues, and pull-requests, reducing the scope of token permissions granted to the release automation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/148)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->