### PR TITLE
ci(bundle-analysis): run on Dependabot PRs to satisfy required check

### DIFF
--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -33,7 +33,6 @@ jobs:
   bundle-analysis:
     name: Bundle Analysis
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
The `bundle-analysis.yml` workflow had `if: github.actor != 'dependabot[bot]'`
on the `bundle-analysis` job. The job is in the required status checks of the
`main` branch ruleset (and posts `codecov/bundles` which is also required).

Combined effect: every Dependabot PR ended up in `BLOCKED` merge state with
`Bundle Analysis = SKIPPED` and `codecov/bundles` missing from the rollup.

`codecov/bundles` is informational by default (no `codecov.yml` configures
a strict threshold), so running the workflow on Dependabot PRs uploads the
bundle data and the check posts SUCCESS without fail-on-growth risk.

Mirrors klodr/gmail-mcp#160.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to ensure comprehensive build analysis across all pull requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/155)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->