### PR TITLE
fix(lint): drain CR findings + valid globs syntax

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -2,10 +2,6 @@
   "extends": ["@commitlint/config-conventional"],
   "rules": {
     "header-max-length": [2, "always", 72],
-    "type-enum": [
-      2,
-      "always",
-      ["feat", "fix", "docs", "chore", "refactor", "test", "ci", "build", "perf", "revert", "style"]
-    ]
+    "type-enum": [2, "always", ["feat", "fix", "docs", "chore", "refactor", "test", "ci", "build"]]
   }
 }

--- a/.yamllint
+++ b/.yamllint
@@ -1,4 +1,4 @@
-# yamllint config — relaxed pour klodr/* (workflows GH Actions friendly)
+# yamllint config — relaxed for klodr/* (workflows GH Actions friendly)
 extends: default
 
 rules:

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "prepare": "husky",
     "prepublishOnly": "NODE_ENV=production npm run build",
     "typecheck": "tsc --noEmit",
-    "lint:md": "markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#coverage\" \"#dist\" \"#CHANGELOG.md\""
+    "lint:md": "markdownlint-cli2 \"**/*.md\" \"#dist\""
   },
   "engines": {
     "node": ">=22.22.2"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "prepare": "husky",
     "prepublishOnly": "NODE_ENV=production npm run build",
     "typecheck": "tsc --noEmit",
-    "lint:md": "markdownlint-cli2 \"**/*.md\" \"#dist\""
+    "lint:md": "markdownlint-cli2 \"**/*.md\" \"#CHANGELOG.md\" \"#node_modules\" \"#coverage\" \"#dist\""
   },
   "engines": {
     "node": ">=22.22.2"


### PR DESCRIPTION
Follow-up to Option C: applies the 3 lint-pack fixes that landed on the branch AFTER auto-merge fired. Drops invalid `markdownlint-globs` (action splits by newline not space), cascades CR findings (yamllint EN header, lint:md DRY, type-enum reduced to 8 standard types).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated commit message validation rules to enforce stricter standards
  * Corrected configuration documentation
  * Enhanced markdown validation to include changelog file checks

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/161)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->