### PR TITLE
fix(ci): align auto-merge filter on klodr-release-please[bot]

### DIFF
--- a/.github/workflows/auto-merge-release-please.yml
+++ b/.github/workflows/auto-merge-release-please.yml
@@ -1,7 +1,7 @@
 name: Auto-merge release-please PR
 
 # Arms `--squash --auto --delete-branch` on the perpetually-updated PR
-# opened by release-please-app[bot]. Once required CI checks go green
+# opened by klodr-release-please[bot]. Once required CI checks go green
 # the PR self-merges, which fires release.yml downstream (signed
 # artifact + npm publish with provenance).
 #
@@ -21,7 +21,7 @@ jobs:
     # the reusable workflow. The reusable also has its own bot-login filter,
     # but matching here means the secrets are only forwarded for the one
     # event that needs them, and human/dependabot PRs short-circuit early.
-    if: ${{ github.event.pull_request.user.login == 'release-please-app[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'klodr-release-please[bot]' }}
     uses: klodr/.github/.github/workflows/reusable-auto-merge-release-please.yml@a44b6ecf0876fde506bbf289b69a3da1efc5f5d1
     secrets:
       RELEASE_PLEASE_CLIENT_ID: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}


### PR DESCRIPTION
The caller filter targeted `release-please-app[bot]` (the OSS app login) but the actual bot operating in klodr/* is the custom App `klodr-release-please[bot]`. Net effect: the `if:` was never true, the reusable workflow was never invoked, auto-merge was never armed on release-please PRs (we've been merging them manually).

Side effect: on Dependabot PRs, the secrets context is restricted so the upfront `secrets:` block validation fails before `if:` evaluates, producing the 'This run likely failed because of a workflow file issue' failure. Updating the filter to the correct bot login lets the job short-circuit (skip) early enough that the validation is no-op for non-target PRs.

Cf `feedback_custom_app_bot_login.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for internal release automation processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/163)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->