### PR TITLE
chore(lint-staged): add prettier --write to all globs

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,20 +96,20 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,mjs,cjs,mts}": [
-      "eslint --max-warnings=0 --no-warn-ignored",
-      "prettier --write"
+      "prettier --write",
+      "eslint --max-warnings=0 --no-warn-ignored"
     ],
     "*.{json,jsonc,json5}": [
-      "eslint --max-warnings=0 --no-warn-ignored",
-      "prettier --write"
+      "prettier --write",
+      "eslint --max-warnings=0 --no-warn-ignored"
     ],
     "*.{yml,yaml}": [
-      "yamllint",
-      "prettier --write"
+      "prettier --write",
+      "yamllint"
     ],
     "*.md": [
-      "markdownlint-cli2",
-      "prettier --write"
+      "prettier --write",
+      "markdownlint-cli2"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -96,16 +96,20 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,mjs,cjs,mts}": [
-      "eslint --max-warnings=0 --no-warn-ignored"
+      "eslint --max-warnings=0 --no-warn-ignored",
+      "prettier --write"
     ],
     "*.{json,jsonc,json5}": [
-      "eslint --max-warnings=0 --no-warn-ignored"
+      "eslint --max-warnings=0 --no-warn-ignored",
+      "prettier --write"
     ],
     "*.{yml,yaml}": [
-      "yamllint"
+      "yamllint",
+      "prettier --write"
     ],
     "*.md": [
-      "markdownlint-cli2"
+      "markdownlint-cli2",
+      "prettier --write"
     ]
   }
 }


### PR DESCRIPTION
Catches prettier issues at commit time (lint-staged auto-fix + re-stage) instead of CI fail. Prevents the kind of late-stage prettier-only fix cycle that just happened on PR #171.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Commit workflow formatting/linting updated to run Prettier alongside existing linters for TypeScript/JavaScript, JSON, YAML, and Markdown files, ensuring consistent code style is applied automatically during commits.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/166)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/166)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->