### PR TITLE
chore(pre-commit): warn on missing system tooling (yamllint)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -32,4 +32,4 @@ if [ -n "$missing" ]; then
   printf '[husky]   (commits touching YAML files will fail until installed)\n'
 fi
 
-npx lint-staged
+npx --no -- lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,35 @@
+#!/usr/bin/env sh
+# Pre-commit template (klodr/* convention).
+#
+# Source of truth: klodr/.github -> .github/templates/husky/pre-commit
+# Copy verbatim into each consumer repo's .husky/pre-commit.
+#
+# Two responsibilities:
+#   1. Warn (non-blocking) when a system-level CLI invoked by lint-staged
+#      is missing on PATH. lint-staged would otherwise fail with a
+#      cryptic "<tool>: command not found" mid-commit.
+#   2. Run `lint-staged`.
+#
+# System deps used by the klodr/* lint-staged configs:
+#   - yamllint  (Python; brew or pip — NOT an npm package)
+#
+# If any of these are missing, print install hints and continue. We do
+# not exit non-zero on missing tooling because lint-staged will skip
+# the YAML hook silently if no YAML files are staged, and we don't
+# want every commit on every machine to be blocked on a tool that may
+# not be needed for this particular commit. The hook itself will fail
+# loudly when YAML is actually staged and the tool is missing.
+
+missing=""
+for tool in yamllint; do
+  command -v "$tool" >/dev/null 2>&1 || missing="$missing $tool"
+done
+
+if [ -n "$missing" ]; then
+  printf '[husky] WARN — missing system tooling:%s\n' "$missing"
+  printf '[husky]   macOS:  brew install%s\n' "$missing"
+  printf '[husky]   Linux:  pip install --user%s\n' "$missing"
+  printf '[husky]   (commits touching YAML files will fail until installed)\n'
+fi
+
 npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,13 +5,18 @@
 # Copy verbatim into each consumer repo's .husky/pre-commit.
 #
 # Two responsibilities:
-#   1. Warn (non-blocking) when a system-level CLI invoked by lint-staged
-#      is missing on PATH. lint-staged would otherwise fail with a
-#      cryptic "<tool>: command not found" mid-commit.
-#   2. Run `lint-staged`.
+#   1. Warn (non-blocking) when a CLI invoked by lint-staged is missing
+#      both from PATH and from the local node_modules/.bin. Otherwise
+#      lint-staged dies mid-commit with a cryptic
+#      "<tool>: command not found".
+#   2. Run `lint-staged` via `npx --no` so a stale/missing node_modules
+#      fails loudly instead of silently fetching an unpinned version.
 #
-# System deps used by the klodr/* lint-staged configs:
-#   - yamllint  (Python; brew or pip — NOT an npm package)
+# Tooling used by the klodr/* lint-staged configs:
+#   - yamllint  → provided by the npm package `yaml-lint` (devDep) which
+#                 installs a `yamllint` binary at
+#                 node_modules/.bin/yamllint. Falls back to a system
+#                 install (brew install yamllint) if you prefer.
 #
 # If any of these are missing, print install hints and continue. We do
 # not exit non-zero on missing tooling because lint-staged will skip
@@ -22,14 +27,17 @@
 
 missing=""
 for tool in yamllint; do
-  command -v "$tool" >/dev/null 2>&1 || missing="$missing $tool"
+  if ! command -v "$tool" >/dev/null 2>&1 \
+     && [ ! -x "./node_modules/.bin/$tool" ]; then
+    missing="$missing $tool"
+  fi
 done
 
 if [ -n "$missing" ]; then
-  printf '[husky] WARN — missing system tooling:%s\n' "$missing"
+  printf '[husky] WARN — missing tooling (PATH + ./node_modules/.bin):%s\n' "$missing"
+  printf '[husky]   npm install                 (preferred — provided as yaml-lint devDep)\n'
   printf '[husky]   macOS:  brew install%s\n' "$missing"
   printf '[husky]   Linux:  pip install --user%s\n' "$missing"
-  printf '[husky]   (commits touching YAML files will fail until installed)\n'
 fi
 
 npx --no -- lint-staged


### PR DESCRIPTION
## What

Adopt the pan-klodr pre-commit pattern: warn (non-blocking) when `yamllint` (system CLI, not npm) is missing from `$PATH`. Avoids the cryptic `yamllint: command not found` mid-commit on fresh clones.

The hook still fails loudly if YAML is staged and the tool is absent — the warning just surfaces the install command (`brew install yamllint` / `pip install --user yamllint`).

Source: canonical template at `klodr/.github/.github/templates/husky/pre-commit`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved pre-commit hook: checks for a YAML linter in system PATH and local modules, prints non-blocking macOS/Linux install hints if missing, then continues to run staged linting using a safer npx invocation to avoid fetching an unexpected tool at commit time.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/168)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/168)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->