### PR TITLE
chore(test): harmonise vitest coverage config with klodr/* ecosystem

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,10 +20,12 @@ export default defineConfig({
       // CI logs.
       reporter: ["text", "lcov", "json"],
       include: ["src/**/*.ts"],
-      // index.ts is the stdio entry point; testing it requires process/stdio
-      // mocking that adds complexity disproportionate to its coverage value.
-      // The actual server logic lives in server.ts.
-      exclude: ["src/**/*.d.ts", "src/index.ts"],
+      // `src/index.ts` is the stdio CLI entry point — a thin shim that
+      // boots `StdioServerTransport`. Testing it requires booting a real
+      // transport, which deadlocks the test runner waiting for the next
+      // stdio frame. The orchestration the shim wraps lives in
+      // `server.ts` and is covered there.
+      exclude: ["src/index.ts"],
     },
   },
 });


### PR DESCRIPTION
## Summary

- Replace the terse `src/index.ts` exclude comment with the canonical block shared across the klodr/* MCP suite (orchestration covered by tests lives in `server.ts`).
- Drop the redundant `src/**/*.d.ts` entry — coverage `include` already restricts to `src/**/*.ts`, so declaration files cannot match.
- Pure documentation / dead-entry cleanup, no behavioural change.

## Test plan
- [x] `npx vitest run --coverage` passes locally (227 tests / 99.62% statements unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test coverage configuration to exclude specific non-testable components and improve clarity of testing practices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/173)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->