### PR TITLE
chore(scripts): canonicalise sync-version with ecosystem

### DIFF
--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -1,32 +1,111 @@
-// Propagate package.json's `version` into the two other places that need it:
-// server.json and src/server.ts. Run automatically by `npm version`.
+// Propagate package.json's `version` into the other places that need it:
+// server.json (top-level + matching package entry) and the `VERSION`
+// constant in src/server.ts (the McpServer factory). Run automatically
+// by `npm version`. Pre-v0.30.0 this targeted src/index.ts where the
+// legacy `new Server({ name, version })` literal lived.
+//
+// Exports `syncVersion(rootDir)` so the unit test in
+// `scripts/sync-version.test.mjs` can drive it against a tempdir-rooted
+// fixture without mutating the real repo. The CLI entrypoint at the
+// bottom calls `syncVersion(process.cwd-derived root)` when the file is
+// executed directly via `node scripts/sync-version.mjs`.
 
 import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-const root = join(dirname(fileURLToPath(import.meta.url)), "..");
-const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
-const v = pkg.version;
+/**
+ * Sync the version field from `<root>/package.json` to:
+ *   - `<root>/server.json` top-level `version`
+ *   - every entry of `<root>/server.json#packages[]` whose
+ *     `identifier` equals `<root>/package.json#name`
+ *   - the `export const VERSION = "..."` literal in `<root>/src/server.ts`
+ *
+ * Throws a descriptive Error if the `VERSION` constant cannot be
+ * located in `src/server.ts` — the CLI entrypoint catches and
+ * `process.exit(1)`s on that throw, the unit test asserts on it.
+ *
+ * @param {string} rootDir - Absolute path to the repo root.
+ * @returns {string} The propagated version.
+ */
+export function syncVersion(rootDir) {
+  const pkg = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf8"));
+  // Validate the parsed shape up-front: a package.json missing
+  // `name` or `version` (or with non-string values) would
+  // otherwise silently propagate `undefined` into server.json and
+  // src/server.ts. Fail fast instead — the script is run by
+  // `npm version`, so a bad package.json at this point is a
+  // definite operator error worth surfacing loudly.
+  if (!pkg || typeof pkg !== "object" || Array.isArray(pkg)) {
+    // `Array.isArray` reject because `typeof [] === "object"`; a
+    // top-level array would silently produce `undefined` on the
+    // `.version` access and the next guard would mis-attribute
+    // the failure to a missing version string.
+    throw new Error("sync-version: package.json did not parse to an object");
+  }
+  if (typeof pkg.version !== "string" || pkg.version.length === 0) {
+    throw new Error("sync-version: package.json#version must be a non-empty string");
+  }
+  if (typeof pkg.name !== "string" || pkg.name.length === 0) {
+    throw new Error("sync-version: package.json#name must be a non-empty string");
+  }
+  const v = pkg.version;
 
-// 1. server.json
-const serverJsonPath = join(root, "server.json");
-const server = JSON.parse(readFileSync(serverJsonPath, "utf8"));
-server.version = v;
-for (const p of server.packages ?? []) {
-  if (p.identifier === pkg.name) p.version = v;
+  // 1. server.json
+  const serverJsonPath = join(rootDir, "server.json");
+  const server = JSON.parse(readFileSync(serverJsonPath, "utf8"));
+  server.version = v;
+  for (const p of server.packages ?? []) {
+    if (p.identifier === pkg.name) p.version = v;
+  }
+  writeFileSync(serverJsonPath, JSON.stringify(server, null, 2) + "\n");
+
+  // 2. src/server.ts — the exported `VERSION` constant (mirrors mercury / faxdrop)
+  const tsPath = join(rootDir, "src", "server.ts");
+  const ts = readFileSync(tsPath, "utf8");
+  // Anchor to a real declaration line — start-of-line + optional
+  // indentation + the exact `export const VERSION = "..."` token
+  // sequence + an optional trailing semicolon + an optional trailing
+  // line comment (e.g. ` // x-release-please-version`). The previous
+  // unanchored shape `(export const VERSION = )"[^"]*"` would
+  // happily rewrite a comment like
+  // `// Old: export const VERSION = "0.0.0"` or a string literal
+  // containing the same byte sequence, silently corrupting the
+  // file. The `m` flag makes `^` match every line start. The
+  // trailing-comment capture group preserves the release-please
+  // marker (and any other annotation) verbatim across the rewrite.
+  const re = /^(\s*export const VERSION = )"[^"]*"(;?)(\s*\/\/.*)?$/m;
+  if (!re.test(ts)) {
+    throw new Error("sync-version: did not find the VERSION constant in src/server.ts");
+  }
+  const updatedTs = ts.replace(re, (_match, prefix, semi, comment) => {
+    // `comment` is `undefined` when the source line has no trailing
+    // comment; coerce to empty string so the rewrite is a no-op
+    // append rather than the string "undefined".
+    return `${prefix}"${v}"${semi}${comment ?? ""}`;
+  });
+  writeFileSync(tsPath, updatedTs);
+
+  return v;
 }
-writeFileSync(serverJsonPath, JSON.stringify(server, null, 2) + "\n");
 
-// 2. src/server.ts
-const tsPath = join(root, "src", "server.ts");
-const ts = readFileSync(tsPath, "utf8");
-const re = /export const VERSION = "[^"]*";/;
-if (!re.test(ts)) {
-  console.error("sync-version: did not find VERSION literal in src/server.ts");
-  process.exit(1);
+// CLI entrypoint: only run when executed directly (`node scripts/sync-version.mjs`).
+// `import.meta.url` is `file:///abs/path` and `process.argv[1]` is the
+// raw absolute path, so converting via fileURLToPath gives a stable
+// equality check that works on both POSIX and Windows.
+/* v8 ignore start -- CLI wrapper (`syncVersion` itself is fully
+   covered by sync-version.test.mjs); spawning the script as a
+   child process from the test runner just to cover seven lines of
+   "is this the main module" plumbing + a console.log + a
+   process.exit is not worth the complexity. */
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+  try {
+    const v = syncVersion(root);
+    console.log(`Synced version → ${v} (server.json, src/server.ts)`);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
 }
-const updatedTs = ts.replace(re, `export const VERSION = "${v}";`);
-writeFileSync(tsPath, updatedTs);
-
-console.log(`Synced version → ${v} (server.json, src/server.ts)`);
+/* v8 ignore stop */

--- a/scripts/sync-version.test.mjs
+++ b/scripts/sync-version.test.mjs
@@ -1,0 +1,227 @@
+// Unit tests for `scripts/sync-version.mjs`. Drive `syncVersion()`
+// against a tempdir-rooted fixture (package.json + server.json +
+// src/server.ts) so the real repo files are never touched.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { syncVersion } from "./sync-version.mjs";
+
+let scratch;
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), "sync-version-test-"));
+  mkdirSync(join(scratch, "src"), { recursive: true });
+});
+
+afterEach(() => {
+  // Guard against `mkdtempSync` failing in beforeEach: if scratch
+  // is still undefined, calling `rmSync(undefined, ...)` throws
+  // TypeError (force: true covers ENOENT, not invalid path types)
+  // and that throw masks the original setup failure that vitest
+  // would otherwise surface to the test report.
+  if (scratch) rmSync(scratch, { recursive: true, force: true });
+});
+
+/**
+ * Hydrate a minimal repo-shape fixture under `scratch`.
+ * Returns the version string written to package.json so the test
+ * can assert the propagation downstream.
+ */
+function writeFixture({
+  pkgVersion = "9.9.9",
+  pkgName = "@klodr/mercury-invoicing-mcp",
+  serverPackages = [{ identifier: "@klodr/mercury-invoicing-mcp", version: "0.0.0" }],
+  tsContent = 'export const VERSION = "0.0.0";\n',
+} = {}) {
+  writeFileSync(
+    join(scratch, "package.json"),
+    JSON.stringify({ name: pkgName, version: pkgVersion }, null, 2),
+  );
+  writeFileSync(
+    join(scratch, "server.json"),
+    JSON.stringify({ version: "0.0.0", packages: serverPackages }, null, 2),
+  );
+  writeFileSync(join(scratch, "src", "server.ts"), tsContent);
+  // Honour the docblock contract — return the version we wrote so
+  // tests can assert propagation downstream without re-deriving it.
+  return pkgVersion;
+}
+
+describe("syncVersion", () => {
+  it("propagates package.json#version to server.json (top-level + matching package)", () => {
+    writeFixture({ pkgVersion: "1.2.3" });
+    const v = syncVersion(scratch);
+    expect(v).toBe("1.2.3");
+    const server = JSON.parse(readFileSync(join(scratch, "server.json"), "utf8"));
+    expect(server.version).toBe("1.2.3");
+    expect(server.packages[0].version).toBe("1.2.3");
+  });
+
+  it("only updates server.json#packages entries whose identifier matches pkg.name", () => {
+    // Regression-trap: an unrelated package entry under server.json
+    // (e.g., a Docker image companion) MUST NOT have its version
+    // bumped just because the npm package's version moved.
+    writeFixture({
+      pkgVersion: "2.0.0",
+      pkgName: "@klodr/mercury-invoicing-mcp",
+      serverPackages: [
+        { identifier: "@klodr/mercury-invoicing-mcp", version: "0.0.0" },
+        { identifier: "@klodr/mercury-invoicing-mcp-docker", version: "0.5.0" },
+      ],
+    });
+    syncVersion(scratch);
+    const server = JSON.parse(readFileSync(join(scratch, "server.json"), "utf8"));
+    expect(server.packages[0].version).toBe("2.0.0");
+    expect(server.packages[1].version).toBe("0.5.0"); // untouched
+  });
+
+  it("tolerates server.json with no `packages` array (top-level only)", () => {
+    writeFixture({ pkgVersion: "0.31.0", serverPackages: undefined });
+    // Manually overwrite server.json to drop the packages key so the
+    // `?? []` branch is exercised.
+    writeFileSync(join(scratch, "server.json"), JSON.stringify({ version: "0.0.0" }, null, 2));
+    expect(() => syncVersion(scratch)).not.toThrow();
+    const server = JSON.parse(readFileSync(join(scratch, "server.json"), "utf8"));
+    expect(server.version).toBe("0.31.0");
+  });
+
+  it("rewrites the VERSION constant in src/server.ts in-place", () => {
+    writeFixture({
+      pkgVersion: "0.30.5",
+      tsContent:
+        '// header\nexport const VERSION = "0.30.0";\n\n// other code below\nconst FOO = "bar";\n',
+    });
+    syncVersion(scratch);
+    const ts = readFileSync(join(scratch, "src", "server.ts"), "utf8");
+    expect(ts).toContain('export const VERSION = "0.30.5";');
+    // Surrounding lines must be untouched.
+    expect(ts).toContain("// header");
+    expect(ts).toContain('const FOO = "bar";');
+    // The old version literal must be GONE (no double assignment).
+    expect(ts).not.toContain('VERSION = "0.30.0"');
+  });
+
+  it("throws a descriptive error when VERSION constant cannot be located", () => {
+    // Pin the regex-not-matched branch — without this, a refactor
+    // that renames the constant (e.g. `MCP_VERSION` instead of
+    // `VERSION`) would silently leave src/server.ts on the old
+    // version string and the package would publish with mismatched
+    // metadata.
+    writeFixture({
+      pkgVersion: "1.0.0",
+      tsContent: 'export const NOT_VERSION = "0.0.0";\n',
+    });
+    expect(() => syncVersion(scratch)).toThrow(
+      /did not find the VERSION constant in src\/server\.ts/,
+    );
+  });
+
+  it("returns the version string for the caller (CLI uses it in the success log)", () => {
+    writeFixture({ pkgVersion: "0.42.0" });
+    const v = syncVersion(scratch);
+    expect(v).toBe("0.42.0");
+  });
+
+  it.each([
+    ["missing version field", JSON.stringify({ name: "@klodr/mercury-invoicing-mcp" })],
+    ["empty version string", JSON.stringify({ name: "@klodr/mercury-invoicing-mcp", version: "" })],
+    ["non-string version", JSON.stringify({ name: "@klodr/mercury-invoicing-mcp", version: 42 })],
+  ])("throws when package.json#version is invalid (%s)", (_label, pkgJson) => {
+    // Pin the up-front version validator. Without it, an absent or
+    // non-string `version` would silently get propagated as
+    // `undefined` into server.json and as `"undefined"` into the
+    // VERSION literal in src/server.ts — a malformed release on
+    // npm. Fail fast at boot instead.
+    writeFixture();
+    writeFileSync(join(scratch, "package.json"), pkgJson);
+    expect(() => syncVersion(scratch)).toThrow(/package\.json#version/);
+  });
+
+  it.each([
+    ["missing name field", JSON.stringify({ version: "1.0.0" })],
+    ["empty name string", JSON.stringify({ name: "", version: "1.0.0" })],
+    ["non-string name", JSON.stringify({ name: 123, version: "1.0.0" })],
+  ])("throws when package.json#name is invalid (%s)", (_label, pkgJson) => {
+    // Symmetric pin for the `name` field. The script uses pkg.name
+    // to match `server.json#packages[].identifier` — if it's
+    // undefined, no entry would match and the per-package version
+    // bump would silently no-op while the top-level still moves.
+    writeFixture();
+    writeFileSync(join(scratch, "package.json"), pkgJson);
+    expect(() => syncVersion(scratch)).toThrow(/package\.json#name/);
+  });
+
+  it("preserves a trailing line comment on the VERSION declaration (release-please marker)", () => {
+    // Pin the trailing-comment branch — release-please's
+    // `extra-files: generic` matcher looks for the
+    // `// x-release-please-version` annotation on the same line as
+    // the version literal. Without this support, sync-version would
+    // strip the annotation on every bump, breaking release-please's
+    // version-detection on the next release. Cover both with-comment
+    // and without-comment forms in the same fixture.
+    writeFixture({
+      pkgVersion: "0.31.0",
+      tsContent:
+        [
+          'export const VERSION = "0.0.0"; // x-release-please-version',
+          'export const OTHER = "kept";',
+        ].join("\n") + "\n",
+    });
+    syncVersion(scratch);
+    const ts = readFileSync(join(scratch, "src", "server.ts"), "utf8");
+    expect(ts).toContain('export const VERSION = "0.31.0"; // x-release-please-version');
+    // The companion declaration on the next line must be untouched.
+    expect(ts).toContain('export const OTHER = "kept";');
+  });
+
+  it("does not rewrite VERSION-like patterns inside comments or string literals", () => {
+    // Pin the anchored regex (`^(\\s*export const VERSION = )"..."(;?)$/m`)
+    // — without the `^...$/m` anchors, the previous unanchored
+    // pattern would happily rewrite a
+    // `// Old: export const VERSION = "0.0.0"` comment or a string
+    // literal containing the same byte sequence, silently corrupting
+    // src/server.ts. Pin: build a fixture with the real declaration
+    // AND a comment + a string literal that reuse the pattern;
+    // assert only the real declaration gets rewritten.
+    writeFixture({
+      pkgVersion: "0.31.0",
+      tsContent:
+        [
+          '// Historical: export const VERSION = "0.1.0";',
+          'const sample = `pre export const VERSION = "0.0.0" mid`;',
+          'export const VERSION = "0.0.0";',
+          '// Trailing: export const VERSION = "9.9.9"',
+        ].join("\n") + "\n",
+    });
+    syncVersion(scratch);
+    const ts = readFileSync(join(scratch, "src", "server.ts"), "utf8");
+    // The real declaration was rewritten.
+    expect(ts).toContain('export const VERSION = "0.31.0";');
+    // The historical comment + the inline string + the trailing
+    // comment are untouched.
+    expect(ts).toContain('// Historical: export const VERSION = "0.1.0";');
+    expect(ts).toContain('const sample = `pre export const VERSION = "0.0.0" mid`;');
+    expect(ts).toContain('// Trailing: export const VERSION = "9.9.9"');
+  });
+
+  it.each([
+    ["JSON null", "null"],
+    ["JSON primitive string", '"x"'],
+    ["JSON primitive number", "42"],
+    ["JSON primitive boolean", "true"],
+    ["JSON top-level array", "[]"],
+  ])("throws when package.json parses to a non-object value (%s)", (_label, raw) => {
+    // The shape validator rejects every non-object JSON parse:
+    // `null` (typeof === "object" needs the explicit `!value`
+    // guard), primitives (string/number/boolean), and top-level
+    // arrays (rejected because `package.json` is contractually an
+    // object, not a list — array indexing into `.version` /
+    // `.name` would silently produce undefined and the downstream
+    // string check would mis-attribute the failure).
+    writeFixture();
+    writeFileSync(join(scratch, "package.json"), raw);
+    expect(() => syncVersion(scratch)).toThrow(/did not parse to an object/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
-    include: ["test/**/*.test.ts"],
+    // Test discovery covers the canonical `test/` tree plus
+    // `scripts/**/*.test.mjs` so the tempdir-driven sync-version unit
+    // test runs alongside the rest of the suite.
+    include: ["test/**/*.test.ts", "scripts/**/*.test.mjs"],
     setupFiles: ["test/setup.ts"],
     restoreMocks: true,
     // Keep the default human-readable reporter and ALSO emit a JUnit XML
@@ -19,13 +22,26 @@ export default defineConfig({
       // PR doesn't touch. `text` keeps the human-readable summary in
       // CI logs.
       reporter: ["text", "lcov", "json"],
-      include: ["src/**/*.ts"],
+      include: ["src/**/*.ts", "scripts/**/*.mjs"],
       // `src/index.ts` is the stdio CLI entry point — a thin shim that
       // boots `StdioServerTransport`. Testing it requires booting a real
       // transport, which deadlocks the test runner waiting for the next
       // stdio frame. The orchestration the shim wraps lives in
       // `server.ts` and is covered there.
-      exclude: ["src/index.ts"],
+      //
+      // `scripts/**/*.test.mjs` is the test file, not the unit under
+      // test, so excluded from coverage measurement.
+      //
+      // `scripts/prod-readonly-test.mjs` and `scripts/sandbox-test.mjs`
+      // are top-level smoke tests that spawn `dist/index.js` against
+      // sandbox / read-only credentials; not unit tests, not subjects
+      // of coverage.
+      exclude: [
+        "src/index.ts",
+        "scripts/**/*.test.mjs",
+        "scripts/prod-readonly-test.mjs",
+        "scripts/sandbox-test.mjs",
+      ],
     },
   },
 });


### PR DESCRIPTION
## Summary

- Align sync-version.mjs with the gmail-mcp canonical shape: exported function for unit-testing, up-front validation on package.json, anchored regex with trailing-comment capture (preserves the release-please marker).
- Add the 19-case unit suite and extend vitest config to discover scripts/**/*.test.mjs.

## Test plan
- [x] `node scripts/sync-version.mjs` succeeds against the live repo
- [x] All 246 tests pass (227 existing + 19 new sync-version)
- [x] Coverage remains at parity with main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for version synchronization functionality.

* **Chores**
  * Refactored version management tooling for improved reusability; enhanced test discovery and coverage configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/174)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->