### PR TITLE
fix(scripts): defer all writes in syncVersion until validation passes

### DIFF
--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -51,14 +51,19 @@ export function syncVersion(rootDir) {
   }
   const v = pkg.version;
 
-  // 1. server.json
+  // 1. Prepare the new server.json payload (do NOT write yet — see
+  // step 3 for the atomic write phase. Writing server.json before
+  // step 2 validates src/server.ts would leave the repo in a
+  // partially bumped state if step 2 throws — server.json shipped
+  // forward, src/server.ts still on the old literal — which then
+  // smuggles a mismatched-metadata release into npm).
   const serverJsonPath = join(rootDir, "server.json");
   const server = JSON.parse(readFileSync(serverJsonPath, "utf8"));
   server.version = v;
   for (const p of server.packages ?? []) {
     if (p.identifier === pkg.name) p.version = v;
   }
-  writeFileSync(serverJsonPath, JSON.stringify(server, null, 2) + "\n");
+  const serverJsonOutput = JSON.stringify(server, null, 2) + "\n";
 
   // 2. src/server.ts — the exported `VERSION` constant (mirrors mercury / faxdrop)
   const tsPath = join(rootDir, "src", "server.ts");
@@ -84,6 +89,17 @@ export function syncVersion(rootDir) {
     // append rather than the string "undefined".
     return `${prefix}"${v}"${semi}${comment ?? ""}`;
   });
+
+  // 3. Atomic write phase — both payloads have been built and
+  // validated, so it is safe to commit them to disk. Writing both
+  // here (instead of writing server.json in step 1) means a regex
+  // miss in step 2 throws BEFORE any file mutates, so a failed
+  // `npm version` does not leave server.json one version ahead of
+  // src/server.ts. fs.writeFileSync is not transactional across
+  // multiple files, but ordering server.json before src/server.ts
+  // gives the next reader at least a self-consistent server.json
+  // even if the second write is interrupted.
+  writeFileSync(serverJsonPath, serverJsonOutput);
   writeFileSync(tsPath, updatedTs);
 
   return v;

--- a/scripts/sync-version.test.mjs
+++ b/scripts/sync-version.test.mjs
@@ -131,12 +131,17 @@ describe("syncVersion", () => {
       tsContent: 'export const NOT_VERSION = "0.0.0";\n',
     });
     const serverJsonBefore = readFileSync(join(scratch, "server.json"), "utf8");
+    const tsBefore = readFileSync(join(scratch, "src", "server.ts"), "utf8");
     expect(() => syncVersion(scratch)).toThrow(/did not find the VERSION constant/);
     const serverJsonAfter = readFileSync(join(scratch, "server.json"), "utf8");
-    // Byte-exact equality — even a re-serialisation with the same
-    // content (rewriting the bumped object) would defeat the
-    // atomicity contract because a later step could still throw.
+    const tsAfter = readFileSync(join(scratch, "src", "server.ts"), "utf8");
+    // Byte-exact equality on BOTH files — even a re-serialisation
+    // with the same content (rewriting the bumped object) would
+    // defeat the atomicity contract because a later step could still
+    // throw. A half-applied bump on EITHER file would smuggle
+    // mismatched metadata into the next release.
     expect(serverJsonAfter).toBe(serverJsonBefore);
+    expect(tsAfter).toBe(tsBefore);
   });
 
   it("returns the version string for the caller (CLI uses it in the success log)", () => {

--- a/scripts/sync-version.test.mjs
+++ b/scripts/sync-version.test.mjs
@@ -118,6 +118,27 @@ describe("syncVersion", () => {
     );
   });
 
+  it("does not partially write when src/server.ts validation fails (atomic on error)", () => {
+    // Pin the atomic-write contract: when `syncVersion` throws on a
+    // regex miss in step 2, NEITHER file must have been mutated. The
+    // previous shape wrote server.json in step 1 before validating
+    // src/server.ts in step 2, so a failed `npm version` would leave
+    // server.json bumped while src/server.ts kept the old literal —
+    // a half-applied bump that would smuggle mismatched metadata
+    // into the next release if the operator missed the throw.
+    writeFixture({
+      pkgVersion: "9.9.9",
+      tsContent: 'export const NOT_VERSION = "0.0.0";\n',
+    });
+    const serverJsonBefore = readFileSync(join(scratch, "server.json"), "utf8");
+    expect(() => syncVersion(scratch)).toThrow(/did not find the VERSION constant/);
+    const serverJsonAfter = readFileSync(join(scratch, "server.json"), "utf8");
+    // Byte-exact equality — even a re-serialisation with the same
+    // content (rewriting the bumped object) would defeat the
+    // atomicity contract because a later step could still throw.
+    expect(serverJsonAfter).toBe(serverJsonBefore);
+  });
+
   it("returns the version string for the caller (CLI uses it in the success log)", () => {
     writeFixture({ pkgVersion: "0.42.0" });
     const v = syncVersion(scratch);


### PR DESCRIPTION
## Summary
- `syncVersion()` now builds the new `server.json` payload in step 1 without writing, validates the `src/server.ts` rewrite in step 2, and only commits both writes in step 3. Avoids a half-applied bump where `server.json` ships forward but `src/server.ts` stays on the old literal.
- Atomicity test asserts `server.json` is byte-identical to its pre-call shape when step 2 throws.

## Test plan
- [x] All 20 sync-version tests pass
- [x] `node scripts/sync-version.mjs` propagates correctly on success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved version synchronization reliability in build scripts through atomic file operations
* **Tests**
  * Added test coverage for error handling in version synchronization process

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/175)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/175)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->