### PR TITLE
ci: fix four workflow errors (pinact, gitleaks, auto-merge, coderabbit)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,11 +16,11 @@ language: en-US
 early_access: false
 
 reviews:
-  profile: assertive          # stricter feedback (vs "chill")
+  profile: assertive # stricter feedback (vs "chill")
   request_changes_workflow: true
   high_level_summary: true
-  poem: false                 # no decorative poetry
-  in_progress_fortune: false  # no fortune-cookie message during reviews
+  poem: false # no decorative poetry
+  in_progress_fortune: false # no fortune-cookie message during reviews
   review_status: true
   collapse_walkthrough: false
   abort_on_close: true
@@ -46,7 +46,7 @@ reviews:
       # The codebase deliberately keeps comments to non-obvious WHY only;
       # function names like `enforceRateLimit` / `redactSensitive` are
       # self-documenting and a forced JSDoc would just paraphrase them.
-      mode: off
+      mode: "off"
     title:
       # Enforce Conventional Commits format + 72-char cap (matches the
       # auto_title_instructions above — this is the gate that actually
@@ -85,4 +85,4 @@ reviews:
 
 chat:
   auto_reply: true
-  art: false                  # no ASCII/emoji art in chat responses
+  art: false # no ASCII/emoji art in chat responses

--- a/.github/workflows/actions-pinned.yml
+++ b/.github/workflows/actions-pinned.yml
@@ -24,7 +24,9 @@ jobs:
 
       - uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
         with:
-          version: v3.9.2
+          # `version` was removed in pinact-action v2: the pinact binary
+          # is now bundled with the action tag, so the action SHA above
+          # is the only thing pinning the pinact version.
           skip_push: "true"
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/auto-merge-release-please.yml
+++ b/.github/workflows/auto-merge-release-please.yml
@@ -12,11 +12,19 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
-permissions:
-  contents: read
-
 jobs:
   call:
+    # The reusable workflow needs to arm `gh pr merge --auto` (writes the
+    # PR's auto-merge field via the PullRequest GraphQL mutation) and
+    # delete the branch on merge — hence `contents: write` (branch delete)
+    # and `pull-requests: write` (auto-merge field). The reusable's
+    # `permissions:` ceiling cannot exceed what the caller grants here,
+    # so the caller grant must match exactly. Job-level (not workflow-
+    # level) so any future job added to this file cannot accidentally
+    # inherit write scope.
+    permissions:
+      contents: write
+      pull-requests: write
     # Defense-in-depth: gate secrets at the caller before they're passed to
     # the reusable workflow. The reusable also has its own bot-login filter,
     # but matching here means the secrets are only forwarded for the one

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -41,3 +41,10 @@ jobs:
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # gitleaks-action v2.3.9 declares `runs.using: node20`, which
+          # GitHub will force to node24 by default starting 2026-06-02
+          # and remove node20 entirely 2026-09-16. Opt into node24 now
+          # to silence the deprecation warning and validate compatibility
+          # before the forced flip. Upstream has not cut a node24 release
+          # since v2.3.9 (2025-04-17); revisit when a successor lands.
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"


### PR DESCRIPTION
Mirrors klodr/eslint-plugin-security-mcp#35.

Four unrelated workflow-config failures; one PR since each is one-line fix.

- `actions-pinned.yml`: pinact-action v2 removed the `version` input — drop it.
- `auto-merge-release-please.yml`: move `permissions:` to job-level with `contents: write` + `pull-requests: write`.
- `gitleaks.yml`: `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to silence Node 20 deprecation.
- `.coderabbit.yaml`: quote `mode: "off"` for yamllint truthy.

## Test plan

- [x] yamllint pass (pre-commit hook)
- [ ] CI green
- [ ] CodeRabbit review pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review platform configuration to optimize review behavior
  * Modernized GitHub Actions workflows for improved dependency management and future Node.js runtime compatibility
  * Adjusted workflow permissions to align with auto-merge requirements

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/176)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->