### PR TITLE
ci(leak-detect): re-pin reusable workflow to fix yq checksum SHA

### DIFF
--- a/.github/workflows/leak-detect.yml
+++ b/.github/workflows/leak-detect.yml
@@ -35,7 +35,7 @@ jobs:
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository
       && github.event.pull_request.user.login != 'dependabot[bot]'
-    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@a2618fb7c675a9f6bbbd68f0f957dd5ffa1b5c10
+    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@e302f5295abbccbfbb36769721cdde1529013ba3
     secrets:
       leak-detect-client-id: ${{ secrets.LEAK_DETECT_CLIENT_ID }}
       leak-detect-app-private-key: ${{ secrets.LEAK_DETECT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Mercury was missed in the May 12 cascade (gmail #181, faxdrop #174, relayfi #93, eslint-plugin #33). The caller still pointed at the pre-fix SHA \`a2618fb7\`, whose yq install step uses the legacy single-column checksum parser. Every PR's leak-detect job now hard-fails with \`no properly formatted checksum lines found\` — release-please PR #177 is currently blocked on it.

Re-pin to \`e302f5295abbccbfbb36769721cdde1529013ba3\` (merge of klodr/.github#27, handle yq's multi-column checksums).

## Test plan

- [ ] leak-detect job passes on this PR
- [ ] release-please #177 unblocks once this lands and the bot re-syncs the branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated leak detection workflow configuration with the latest dependency reference.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/178)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->