### PR TITLE
chore(lint): reactivate 6 markdownlint rules previously disabled

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,24 +1,18 @@
 {
   // markdownlint-cli2 — relaxed config for klodr/* MCP+plugin docs.
   // See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+  // 5 rules disabled — all justified by content shape, not by author
+  // convenience. Everything else (MD012, MD028, MD029, MD036, MD049,
+  // MD050) is on; commit hooks + CI now reject the corresponding
+  // findings instead of letting them rot.
   "default": true,
-  "MD012": false, // multiple consecutive blank lines: cosmetic
   "MD013": false, // line-length: README has long URLs / badges
   "MD024": { "siblings_only": true }, // duplicate headings OK in CHANGELOG sections
-  "MD028": false, // blank line inside blockquote: useful for separating cite paragraphs
-  "MD029": false, // ordered list prefix: accept any style (1.1.1, 1.2.3, mixed)
   "MD033": false, // inline HTML allowed (badges, details/summary)
   "MD034": false, // bare URLs allowed (some places intentional)
-  "MD036": false, // emphasis as heading: false positives on snapshot dates etc.
   "MD041": false, // first line H1: badges/comments may precede
   "MD046": { "style": "fenced" }, // code block style: fenced
-  "MD049": false, // emphasis style: asterisk OR underscore
-  "MD050": false, // strong style: asterisk OR underscore
-  "MD060": false, // table column alignment: compact OR aligned, both OK
+  "MD060": false, // table column alignment: too many existing tables in compact-but-unaligned style
   "globs": ["**/*.md"],
-  "ignores": [
-    "node_modules/**",
-    "coverage/**",
-    "CHANGELOG.md"
-  ]
+  "ignores": ["node_modules/**", "coverage/**", "CHANGELOG.md"],
 }

--- a/README.md
+++ b/README.md
@@ -231,18 +231,18 @@ Restart the gateway (`docker restart openclaw-openclaw-gateway-1` or your equiva
 > `getsendmoneyapprovalrequest`), users (`getuser`, `getusers`),
 > Mercury Raise SAFE (`getsaferequest(s)`, `getsaferequestdocument`),
 > and OAuth flow (`obtainaccesstoken`, `startoauth2flow`).
-
+>
 > Mercury does **not** expose `list_send_money_requests`, COA Templates
 > or Journal Entries via the public API at all — those features are
 > dashboard-only.
-
+>
 > There is **no `send_invoice` endpoint** anywhere (API or dashboard).
 > An invoice email is only sent when the invoice is created with
 > `sendEmailOption: "SendNow"`. To send a copy later, download the
 > invoice PDF (Mercury UI button "Download PDF", or the
 > `getinvoicepdf` endpoint — not yet wrapped, see "Endpoints not yet
 > wrapped" above) and email it manually.
-
+>
 > Tools available depend on your Mercury API token scope. The server
 > registers all 34 tools but Mercury will reject unauthorized operations
 > at the API level.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,4 +23,3 @@ Loose planning horizon of ~12 months. The MCP follows Mercury's own API surface 
 ## Compliance / governance
 
 - **Second maintainer → OpenSSF Gold** — actively welcome co-maintainership via `.github/CODEOWNERS` once a contributor has several merged PRs. Gold requires ≥2 active maintainers; that's the gating constraint.
-


### PR DESCRIPTION
## Summary

Reactivates **MD012/MD028/MD029/MD036/MD049/MD050** in \`.markdownlint.jsonc\`. Empirical audit found four findings:

- \`docs/ROADMAP.md:27\` MD012 — trailing double-newline collapsed.
- \`README.md:234/238/245\` MD028 ×3 — four consecutive notes joined into a single multi-paragraph blockquote via \`>\` lines (canonical MD028 fix). Rendering unchanged on GFM.

The four kept disables (MD013/MD033/MD034/MD041) are structurally justified.

**MD060** stays off — 54 findings on existing tables.

## Test plan

- [x] \`markdownlint-cli2\` clean on \`**/*.md\` (0 errors)
- [ ] CI green
- [ ] CodeRabbit review pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted README endpoints documentation for improved clarity.
  * Updated project roadmap to reflect OpenSSF Gold compliance milestone with expanded maintainer support.

* **Chores**
  * Enhanced markdown linting configuration standards.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/179)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->