### PR TITLE
fix(verify-release): pin cosign predicate to SLSA Provenance v1

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -24,8 +24,8 @@ jobs:
       startsWith(github.event.workflow_run.head_branch, 'v')
     runs-on: ubuntu-latest
     permissions:
-      contents: read         # gh release download
-      attestations: read     # gh attestation verify
+      contents: read # gh release download
+      attestations: read # gh attestation verify
     env:
       PKG: mercury-invoicing-mcp
       TAG: ${{ github.event.workflow_run.head_branch }}
@@ -200,8 +200,15 @@ jobs:
       - name: Path 3 — cosign verify-blob-attestation
         # Same hardening: replace the open identity-regexp with the exact
         # Fulcio SAN that release.yml at this tag would have produced.
+        #
+        # `--type slsaprovenance1` pins the predicate to SLSA Provenance
+        # v1 — the shape `actions/attest-build-provenance@v4.x` emits.
+        # Cosign defaults to `--type custom` and would otherwise reject
+        # the bundle with `invalid predicate type, expected custom got
+        # https://slsa.dev/provenance/v1`.
         run: |
           cosign verify-blob-attestation \
+            --type slsaprovenance1 \
             --bundle verify-assets/index.js.sigstore \
             --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/release.yml@refs/tags/${TAG}" \
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \


### PR DESCRIPTION
## Summary

`cosign verify-blob-attestation` defaults to `--type custom` but `actions/attest-build-provenance@v4.x` emits SLSA Provenance v1. Path 3 of `verify-release.yml` therefore fails on every release with:

```
Error: invalid predicate type, expected custom got https://slsa.dev/provenance/v1
```

Adds `--type slsaprovenance1` to the `cosign verify-blob-attestation` invocation. Same fix cascades on the other 3 callers that share the workflow shape (eslint-plugin PR #37, faxdrop, gmail).

## Test plan

- [ ] Next release tag triggers verify-release and Path 3 passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release verification workflow to enhance security validation processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/180)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->