### PR TITLE
feat(tools): declare openWorldHint:true on every tool

### DIFF
--- a/src/tools/accounts.ts
+++ b/src/tools/accounts.ts
@@ -21,7 +21,7 @@ export function registerAccountTools(server: McpServer, client: MercuryClient): 
       const data = await client.get("/accounts");
       return textResult(data);
     },
-    { title: "List Accounts", readOnlyHint: true },
+    { title: "List Accounts", readOnlyHint: true, openWorldHint: true },
   );
 
   defineTool(
@@ -43,6 +43,6 @@ export function registerAccountTools(server: McpServer, client: MercuryClient): 
       const data = await client.get(`/account/${accountId}`);
       return textResult(data);
     },
-    { title: "Get Account", readOnlyHint: true },
+    { title: "Get Account", readOnlyHint: true, openWorldHint: true },
   );
 }

--- a/src/tools/cards.ts
+++ b/src/tools/cards.ts
@@ -23,6 +23,6 @@ export function registerCardTools(server: McpServer, client: MercuryClient): voi
       const data = await client.get(`/account/${accountId}/cards`);
       return textResult(data);
     },
-    { title: "List Cards", readOnlyHint: true },
+    { title: "List Cards", readOnlyHint: true, openWorldHint: true },
   );
 }

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -20,6 +20,6 @@ export function registerCategoryTools(server: McpServer, client: MercuryClient):
       const data = await client.get("/categories");
       return textResult(data);
     },
-    { title: "List Categories", readOnlyHint: true },
+    { title: "List Categories", readOnlyHint: true, openWorldHint: true },
   );
 }

--- a/src/tools/credit.ts
+++ b/src/tools/credit.ts
@@ -39,7 +39,7 @@ export function registerCreditTools(server: McpServer, client: MercuryClient): v
       const data = await client.get("/credit");
       return textResult(data);
     },
-    { title: "List Credit Accounts", readOnlyHint: true },
+    { title: "List Credit Accounts", readOnlyHint: true, openWorldHint: true },
   );
 
   defineTool(
@@ -78,6 +78,6 @@ export function registerCreditTools(server: McpServer, client: MercuryClient): v
       const data = await client.get(`/account/${accountId}/transactions`, query);
       return textResult(data);
     },
-    { title: "List Credit Transactions", readOnlyHint: true },
+    { title: "List Credit Transactions", readOnlyHint: true, openWorldHint: true },
   );
 }

--- a/src/tools/customers.ts
+++ b/src/tools/customers.ts
@@ -44,7 +44,7 @@ export function registerCustomerTools(server: McpServer, client: MercuryClient):
       const data = await client.get("/ar/customers", query);
       return textResult(data);
     },
-    { title: "List Customers", readOnlyHint: true },
+    { title: "List Customers", readOnlyHint: true, openWorldHint: true },
   );
 
   defineTool(
@@ -66,7 +66,7 @@ export function registerCustomerTools(server: McpServer, client: MercuryClient):
       const data = await client.get(`/ar/customers/${customerId}`);
       return textResult(data);
     },
-    { title: "Get Customer", readOnlyHint: true },
+    { title: "Get Customer", readOnlyHint: true, openWorldHint: true },
   );
 
   defineTool(
@@ -92,7 +92,7 @@ export function registerCustomerTools(server: McpServer, client: MercuryClient):
       const data = await client.post("/ar/customers", args);
       return textResult(data);
     },
-    { title: "Create Customer", destructiveHint: false },
+    { title: "Create Customer", destructiveHint: false, openWorldHint: true },
   );
 
   defineTool(
@@ -119,7 +119,7 @@ export function registerCustomerTools(server: McpServer, client: MercuryClient):
       const data = await client.patch(`/ar/customers/${customerId}`, body);
       return textResult(data);
     },
-    { title: "Update Customer", destructiveHint: false },
+    { title: "Update Customer", destructiveHint: false, openWorldHint: true },
   );
 
   defineTool(
@@ -143,6 +143,6 @@ export function registerCustomerTools(server: McpServer, client: MercuryClient):
       const data = await client.delete(`/ar/customers/${customerId}`);
       return textResult(data);
     },
-    { title: "Delete Customer", destructiveHint: true },
+    { title: "Delete Customer", destructiveHint: true, openWorldHint: true },
   );
 }

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -51,7 +51,7 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
       const data = await client.get("/ar/invoices", query);
       return textResult(data);
     },
-    { title: "List Invoices", readOnlyHint: true },
+    { title: "List Invoices", readOnlyHint: true, openWorldHint: true },
   );
 
   defineTool(
@@ -73,7 +73,7 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
       const data = await client.get(`/ar/invoices/${invoiceId}`);
       return textResult(data);
     },
-    { title: "Get Invoice", readOnlyHint: true },
+    { title: "Get Invoice", readOnlyHint: true, openWorldHint: true },
   );
 
   defineTool(
@@ -136,7 +136,7 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
       const data = await client.post("/ar/invoices", body);
       return textResult(data);
     },
-    { title: "Create Invoice", destructiveHint: false },
+    { title: "Create Invoice", destructiveHint: false, openWorldHint: true },
   );
 
   defineTool(
@@ -188,7 +188,7 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
       const data = await client.post(`/ar/invoices/${invoiceId}`, merged);
       return textResult(data);
     },
-    { title: "Update Invoice", destructiveHint: false },
+    { title: "Update Invoice", destructiveHint: false, openWorldHint: true },
   );
 
   // Note: Mercury does not expose POST /ar/invoices/{id}/send via the public
@@ -216,7 +216,7 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
       const data = await client.post(`/ar/invoices/${invoiceId}/cancel`);
       return textResult(data);
     },
-    { title: "Cancel Invoice", destructiveHint: true },
+    { title: "Cancel Invoice", destructiveHint: true, openWorldHint: true },
   );
 
   defineTool(
@@ -238,6 +238,6 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
       const data = await client.get(`/ar/invoices/${invoiceId}/attachments`);
       return textResult(data);
     },
-    { title: "List Invoice Attachments", readOnlyHint: true },
+    { title: "List Invoice Attachments", readOnlyHint: true, openWorldHint: true },
   );
 }

--- a/src/tools/organization.ts
+++ b/src/tools/organization.ts
@@ -20,6 +20,6 @@ export function registerOrganizationTools(server: McpServer, client: MercuryClie
       const data = await client.get("/organization");
       return textResult(data);
     },
-    { title: "Get Organization", readOnlyHint: true },
+    { title: "Get Organization", readOnlyHint: true, openWorldHint: true },
   );
 }

--- a/src/tools/recipients.ts
+++ b/src/tools/recipients.ts
@@ -22,7 +22,7 @@ export function registerRecipientTools(server: McpServer, client: MercuryClient)
       const data = await client.get("/recipients");
       return textResult(data);
     },
-    { title: "List Recipients", readOnlyHint: true },
+    { title: "List Recipients", readOnlyHint: true, openWorldHint: true },
   );
 
   defineTool(
@@ -53,7 +53,7 @@ export function registerRecipientTools(server: McpServer, client: MercuryClient)
       const data = await client.post(`/recipient/${recipientId}`, body);
       return textResult(data);
     },
-    { title: "Update Recipient", destructiveHint: false },
+    { title: "Update Recipient", destructiveHint: false, openWorldHint: true },
   );
 
   defineTool(
@@ -110,6 +110,6 @@ export function registerRecipientTools(server: McpServer, client: MercuryClient)
       const data = await client.post("/recipients", { ...body, idempotencyKey: idem });
       return textResult(data);
     },
-    { title: "Add Recipient", destructiveHint: false, idempotentHint: true },
+    { title: "Add Recipient", destructiveHint: false, idempotentHint: true, openWorldHint: true },
   );
 }

--- a/src/tools/statements.ts
+++ b/src/tools/statements.ts
@@ -25,6 +25,6 @@ export function registerStatementTools(server: McpServer, client: MercuryClient)
       const data = await client.get(`/account/${accountId}/statements`, query);
       return textResult(data);
     },
-    { title: "List Statements", readOnlyHint: true },
+    { title: "List Statements", readOnlyHint: true, openWorldHint: true },
   );
 }

--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -39,7 +39,7 @@ export function registerTransactionTools(server: McpServer, client: MercuryClien
       const data = await client.get(`/account/${accountId}/transactions`, query);
       return textResult(data);
     },
-    { title: "List Transactions", readOnlyHint: true },
+    { title: "List Transactions", readOnlyHint: true, openWorldHint: true },
   );
 
   defineTool(
@@ -62,7 +62,7 @@ export function registerTransactionTools(server: McpServer, client: MercuryClien
       const data = await client.get(`/account/${accountId}/transaction/${transactionId}`);
       return textResult(data);
     },
-    { title: "Get Transaction", readOnlyHint: true },
+    { title: "Get Transaction", readOnlyHint: true, openWorldHint: true },
   );
 
   defineTool(
@@ -101,7 +101,7 @@ export function registerTransactionTools(server: McpServer, client: MercuryClien
       });
       return textResult(data);
     },
-    { title: "Send Money", destructiveHint: true, idempotentHint: true },
+    { title: "Send Money", destructiveHint: true, idempotentHint: true, openWorldHint: true },
   );
 
   defineTool(
@@ -137,7 +137,7 @@ export function registerTransactionTools(server: McpServer, client: MercuryClien
       const data = await client.patch(`/transaction/${transactionId}`, body);
       return textResult(data);
     },
-    { title: "Update Transaction", destructiveHint: false },
+    { title: "Update Transaction", destructiveHint: false, openWorldHint: true },
   );
 
   defineTool(
@@ -171,7 +171,12 @@ export function registerTransactionTools(server: McpServer, client: MercuryClien
       const data = await client.post(`/transfer`, { ...body, idempotencyKey: idem });
       return textResult(data);
     },
-    { title: "Create Internal Transfer", destructiveHint: false, idempotentHint: true },
+    {
+      title: "Create Internal Transfer",
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
   );
 
   defineTool(
@@ -210,6 +215,11 @@ export function registerTransactionTools(server: McpServer, client: MercuryClien
       });
       return textResult(data);
     },
-    { title: "Request Send Money", destructiveHint: true, idempotentHint: true },
+    {
+      title: "Request Send Money",
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
   );
 }

--- a/src/tools/treasury.ts
+++ b/src/tools/treasury.ts
@@ -21,7 +21,7 @@ export function registerTreasuryTools(server: McpServer, client: MercuryClient):
       const data = await client.get("/treasury");
       return textResult(data);
     },
-    { title: "Get Treasury", readOnlyHint: true },
+    { title: "Get Treasury", readOnlyHint: true, openWorldHint: true },
   );
 
   defineTool(
@@ -47,7 +47,7 @@ export function registerTreasuryTools(server: McpServer, client: MercuryClient):
       const data = await client.get(`/treasury/${accountId}/transactions`, query);
       return textResult(data);
     },
-    { title: "List Treasury Transactions", readOnlyHint: true },
+    { title: "List Treasury Transactions", readOnlyHint: true, openWorldHint: true },
   );
 
   defineTool(
@@ -69,6 +69,6 @@ export function registerTreasuryTools(server: McpServer, client: MercuryClient):
       const data = await client.get(`/treasury/${accountId}/statements`);
       return textResult(data);
     },
-    { title: "List Treasury Statements", readOnlyHint: true },
+    { title: "List Treasury Statements", readOnlyHint: true, openWorldHint: true },
   );
 }

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -138,7 +138,7 @@ export function registerWebhookTools(server: McpServer, client: MercuryClient): 
       const data = await client.get("/webhooks");
       return textResult(data);
     },
-    { title: "List Webhooks", readOnlyHint: true },
+    { title: "List Webhooks", readOnlyHint: true, openWorldHint: true },
   );
 
   defineTool(
@@ -160,7 +160,7 @@ export function registerWebhookTools(server: McpServer, client: MercuryClient): 
       const data = await client.get(`/webhooks/${webhookId}`);
       return textResult(data);
     },
-    { title: "Get Webhook", readOnlyHint: true },
+    { title: "Get Webhook", readOnlyHint: true, openWorldHint: true },
   );
 
   defineTool(
@@ -187,7 +187,7 @@ export function registerWebhookTools(server: McpServer, client: MercuryClient): 
       const data = await client.post("/webhooks", { url, events });
       return textResult(data);
     },
-    { title: "Create Webhook", destructiveHint: false },
+    { title: "Create Webhook", destructiveHint: false, openWorldHint: true },
   );
 
   defineTool(
@@ -216,7 +216,7 @@ export function registerWebhookTools(server: McpServer, client: MercuryClient): 
       const data = await client.post(`/webhooks/${webhookId}`, body);
       return textResult(data);
     },
-    { title: "Update Webhook", destructiveHint: false },
+    { title: "Update Webhook", destructiveHint: false, openWorldHint: true },
   );
 
   defineTool(
@@ -240,6 +240,6 @@ export function registerWebhookTools(server: McpServer, client: MercuryClient): 
       const data = await client.delete(`/webhooks/${webhookId}`);
       return textResult(data);
     },
-    { title: "Delete Webhook", destructiveHint: true },
+    { title: "Delete Webhook", destructiveHint: true, openWorldHint: true },
   );
 }


### PR DESCRIPTION
## Summary

All 36 tools in this server hit a live external API — by definition "open world" interactions. The hint was missing from every annotation block. Per the [MCP tool-annotations spec](https://spec.modelcontextprotocol.io/specification/server/tools/#tool-annotations), `openWorldHint: true` signals to the host that the effect is non-local.

Pure metadata, no runtime behaviour change.

Cascade with klodr/gmail-mcp#185 and the third klodr/* MCP server.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated and enhanced tool metadata configuration across all major modules: accounts, cards, categories, credit, customers, invoices, organization, recipients, statements, transactions, treasury, and webhooks.
  * Tool definitions now include additional metadata hints for improved compatibility with client systems and enhanced tool presentation.
  * All existing tool functionality and behavior remain unchanged.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/181)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->