### PR TITLE
fix(ci): add top-level permissions: contents: read to auto-merge

### DIFF
--- a/.github/workflows/auto-merge-release-please.yml
+++ b/.github/workflows/auto-merge-release-please.yml
@@ -12,6 +12,15 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+# Workflow-level permissions are read-only. The `call` job below
+# escalates only the writes the reusable needs (contents +
+# pull-requests). Without this top-level cap, Scorecard's
+# Token-Permissions check flags the workflow on the missing
+# default and any future job added here would inherit the
+# runner's GITHUB_TOKEN scope.
+permissions:
+  contents: read
+
 jobs:
   call:
     # The reusable workflow needs to arm `gh pr merge --auto` (writes the


### PR DESCRIPTION
## Summary

Scorecard's `Token-Permissions` check flagged the missing top-level `permissions:` block on `auto-merge-release-please.yml`. Adds `permissions: contents: read` at workflow level; the single `call` job below already declares its own job-level escalation (`contents: write` + `pull-requests: write`) for the reusable's auto-merge + branch-delete.

## Test plan

- [x] yamllint / actionlint clean (handled by reusable-lint-yaml-md CI)
- [x] No behavioural change: top-level read does not narrow the job-level write
- [x] Mirrors the cascade landed on the 3 sibling klodr/* repos (#39 eslint-plugin, #180 faxdrop, #186 gmail)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated release workflow security by enforcing read-only permissions at the workflow level, ensuring proper permission isolation and preventing unintended permission inheritance during the release process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/183)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->