### PR TITLE
chore(lint): adopt eslint-plugin-unicorn (pass 1)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,7 @@ import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import promise from "eslint-plugin-promise";
 import importX from "eslint-plugin-import-x";
+import unicorn from "eslint-plugin-unicorn";
 import jsonc from "eslint-plugin-jsonc";
 import prettier from "eslint-config-prettier";
 
@@ -38,7 +39,25 @@ export default tseslint.config(
       promise.configs["flat/recommended"],
       importX.flatConfigs.recommended,
       importX.flatConfigs.typescript,
+      unicorn.configs["flat/recommended"],
     ],
+    rules: {
+      // eslint-plugin-unicorn pass 1. See klodr/eslint-plugin-security-mcp#41 + klodr/gmail-mcp#188 for the policy.
+      "unicorn/prevent-abbreviations": "off",
+      "unicorn/no-null": "off",
+      "unicorn/no-array-reduce": "off",
+      "unicorn/no-process-exit": "off",
+      "unicorn/import-style": "off",
+      "unicorn/prefer-top-level-await": "off",
+      "unicorn/no-array-callback-reference": "off",
+      "unicorn/text-encoding-identifier-case": "off",
+      "unicorn/no-array-for-each": "off",
+      "unicorn/prefer-single-call": "off",
+      "unicorn/no-array-sort": "off",
+      "unicorn/catch-error-name": "off",
+      "unicorn/number-literal-case": "off",
+      "unicorn/switch-case-braces": "off",
+    },
   },
   // JSON / JSONC / JSON5 linting via eslint-plugin-jsonc — `recommended-with-jsonc`
   // applies the JSONC parser to plain `.json` too, so trailing commas in tsconfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint-plugin-import-x": "^4.16.2",
         "eslint-plugin-jsonc": "^3.1.2",
         "eslint-plugin-promise": "^7.3.0",
+        "eslint-plugin-unicorn": "^64.0.0",
         "fast-check": "^4.7.0",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.4",
@@ -3045,6 +3046,19 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -3093,6 +3107,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/builtin-modules": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.2.0.tgz",
+      "integrity": "sha512-02yxLeyxF4dNl6SlY6/5HfRSrSdZ/sCPoxy2kZNP5dZZX8LSAD9aE2gtJIUgWrsQTiMPl3mxESyrobSwvRGisQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bundle-require": {
@@ -3169,6 +3230,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -3178,6 +3260,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/character-entities": {
       "version": "2.0.2",
@@ -3226,6 +3315,45 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clean-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
+      "integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/clean-regexp/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/cli-cursor": {
@@ -3480,6 +3608,20 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-js-compat": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -3692,6 +3834,13 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.354",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.354.tgz",
+      "integrity": "sha512-JaBHwWcfIdmSAfWM5l3uwjGd431j8YEMikZ+K/2nXVuBqJKyZ0f+2h4n4JY5AyNiZmnY9qQr2RU3v9DxDmHMNg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -4124,6 +4273,40 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn": {
+      "version": "64.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-64.0.0.tgz",
+      "integrity": "sha512-rNZwalHh8i0UfPlhNwg5BTUO1CMdKNmjqe+TgzOTZnpKoi8VBgsW7u9qCHIdpxEzZ1uwrJrPF0uRb7l//K38gA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "change-case": "^5.4.4",
+        "ci-info": "^4.4.0",
+        "clean-regexp": "^1.0.0",
+        "core-js-compat": "^3.49.0",
+        "find-up-simple": "^1.0.1",
+        "globals": "^17.4.0",
+        "indent-string": "^5.0.0",
+        "is-builtin-module": "^5.0.0",
+        "jsesc": "^3.1.0",
+        "pluralize": "^8.0.0",
+        "regexp-tree": "^0.1.27",
+        "regjsparser": "^0.13.0",
+        "semver": "^7.7.4",
+        "strip-indent": "^4.1.1"
+      },
+      "engines": {
+        "node": "^20.10.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.38.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -4559,6 +4742,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fix-dts-default-cjs-exports": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
@@ -4748,6 +4944,19 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4945,6 +5154,19 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -5011,6 +5233,22 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-builtin-module": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-5.0.0.tgz",
+      "integrity": "sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtin-modules": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
@@ -5221,6 +5459,19 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -6953,6 +7204,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7240,6 +7498,16 @@
         "pathe": "^2.0.1"
       }
     },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
@@ -7469,6 +7737,29 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
+    "node_modules/regjsparser": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+      "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jsesc": "~3.1.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
       }
     },
     "node_modules/require-directory": {
@@ -8024,6 +8315,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+      "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -8393,6 +8697,37 @@
         "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-jsonc": "^3.1.2",
     "eslint-plugin-promise": "^7.3.0",
+    "eslint-plugin-unicorn": "^64.0.0",
     "fast-check": "^4.7.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.4",

--- a/src/client.ts
+++ b/src/client.ts
@@ -104,7 +104,7 @@ export class MercuryClient {
     const res = await fetch(url, {
       method,
       headers,
-      body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
+      body: init.body === undefined ? undefined : JSON.stringify(init.body),
       signal: AbortSignal.timeout(30_000),
       // Fail closed on any 30x. The default `redirect: "follow"` would
       // let undici chase a Location header transparently — bouncing the

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -212,8 +212,8 @@ function persistCallHistory(): void {
  * legitimate RMW (a few ms) but short enough that recovery on
  * crash/SIGKILL is automatic on the next call.
  */
-const LOCK_TIMEOUT_MS = 2_000;
-const LOCK_STALE_MS = 5_000;
+const LOCK_TIMEOUT_MS = 2000;
+const LOCK_STALE_MS = 5000;
 const LOCK_RETRY_MS = 25;
 
 function getLockFile(): string {

--- a/src/prompts/_shared.ts
+++ b/src/prompts/_shared.ts
@@ -31,5 +31,5 @@
 const NACHA_ALLOWLIST = /[^A-Za-z0-9 ()!#$%&'*+\-./:;=?@[\]^_{|}]/g;
 
 export function promptSafe(value: string): string {
-  return value.replace(NACHA_ALLOWLIST, "").trim();
+  return value.replaceAll(NACHA_ALLOWLIST, "").trim();
 }

--- a/src/prompts/invoicing.ts
+++ b/src/prompts/invoicing.ts
@@ -81,7 +81,7 @@ const CreateInvoiceArgs = {
       message:
         "amount must be a decimal dollar string with at most 2 fractional digits (e.g. `1250.00`)",
     })
-    .refine((v) => parseFloat(v) >= 0.01, {
+    .refine((v) => Number.parseFloat(v) >= 0.01, {
       message: "amount must be at least 0.01 USD",
     })
     .describe(

--- a/src/prompts/recipes.ts
+++ b/src/prompts/recipes.ts
@@ -54,7 +54,7 @@ const SendAchArgs = {
       message:
         "amount must be a decimal dollar string with at most 2 fractional digits (e.g. `150.00`)",
     })
-    .refine((v) => parseFloat(v) >= 0.01, {
+    .refine((v) => Number.parseFloat(v) >= 0.01, {
       message: "amount must be at least 0.01 USD",
     })
     .describe(
@@ -227,7 +227,7 @@ export function registerRecipePrompts(server: McpServer): void {
                     `them.\n`) +
                 `4. Before calling \`mercury_send_money\`, echo a single-line confirmation:\n` +
                 `   "Send ${a} USD via ACH from <account> to <recipient>` +
-                (m ? ` with memo \\"${m}\\"` : "") +
+                (m ? String.raw` with memo \"${m}\"` : "") +
                 `. Confirm?" and WAIT for an explicit yes.\n` +
                 `5. Once confirmed, call \`mercury_send_money\` with:\n` +
                 `   - accountId: <source account UUID>\n` +

--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -52,7 +52,7 @@ const CONTROL_AND_INVISIBLE =
 /* eslint-enable no-control-regex */
 
 export function stripControl(text: string): string {
-  return text.replace(CONTROL_AND_INVISIBLE, "");
+  return text.replaceAll(CONTROL_AND_INVISIBLE, "");
 }
 
 /**
@@ -107,7 +107,11 @@ const FENCE_CLOSE = "\n</untrusted-tool-output>";
 const CLOSE_TAG_RE = /<\/untrusted-tool-output>/gi;
 
 export function fence(text: string): string {
-  return FENCE_OPEN + text.replace(CLOSE_TAG_RE, "\\u003c/untrusted-tool-output>") + FENCE_CLOSE;
+  return (
+    FENCE_OPEN +
+    text.replaceAll(CLOSE_TAG_RE, String.raw`\u003c/untrusted-tool-output>`) +
+    FENCE_CLOSE
+  );
 }
 
 export function sanitizeForLlm(text: string): string {

--- a/src/tools/_shared.ts
+++ b/src/tools/_shared.ts
@@ -4,9 +4,6 @@ import { z, ZodRawShape } from "zod";
 import { wrapToolHandler, type ToolResult } from "../middleware.js";
 import { sanitizeJsonValues } from "../sanitize.js";
 
-export type { ToolResult };
-export type { ToolAnnotations };
-
 /**
  * Build a ToolResult from a JSON-shaped response. The LLM-display
  * surface (`content[0].text`) is a parseable JSON string with every
@@ -55,3 +52,6 @@ export function defineTool<S extends ZodRawShape>(
     wrapped,
   );
 }
+
+export { type ToolResult } from "../middleware.js";
+export { type ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -108,8 +108,8 @@ const HttpsWebhookUrl = z
       // code and showed up as an uncovered branch on Codecov.
       const firstHextet = Number.parseInt(host.split(":")[0], 16);
       if (!Number.isNaN(firstHextet)) {
-        if ((firstHextet & 0xfe00) === 0xfc00) return false; // fc00::/7 (ULA)
-        if ((firstHextet & 0xffc0) === 0xfe80) return false; // fe80::/10 (link-local)
+        if ((firstHextet & 0xfe_00) === 0xfc_00) return false; // fc00::/7 (ULA)
+        if ((firstHextet & 0xff_c0) === 0xfe_80) return false; // fe80::/10 (link-local)
       }
 
       return true;


### PR DESCRIPTION
Pass 1 of the klodr/* unicorn cascade. `unicorn/flat/recommended` with the 14-rule disable set landing across all 5 family repos.

Sibling PRs: klodr/eslint-plugin-security-mcp#41, klodr/faxdrop-mcp#182, klodr/gmail-mcp#188. Pass 2 arbitrates rule-by-rule once the family's residuals are mapped.

`npm run lint && npm test` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Integrated ESLint Unicorn plugin for enhanced code quality enforcement
  * Updated development dependencies

* **Refactor**
  * Optimized internal string handling and validation logic across modules
  * Improved middleware lock timeout configurations
  * Enhanced request serialization efficiency
  * Reorganized type exports for better code maintainability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/185)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->