### PR TITLE
chore(lint): enable prevent-abbreviations with klodr/* allowList

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,7 +43,31 @@ export default tseslint.config(
     ],
     rules: {
       // eslint-plugin-unicorn pass 1. See klodr/eslint-plugin-security-mcp#41 + klodr/gmail-mcp#188 for the policy.
-      "unicorn/prevent-abbreviations": "off",
+      "unicorn/prevent-abbreviations": [
+        "error",
+        {
+          replacements: {
+            args: false,
+            arg: false,
+            opts: false,
+            msg: false,
+            err: false,
+            res: false,
+            val: false,
+            tmp: false,
+            env: false,
+            pkg: false,
+            obj: false,
+            params: false,
+            ext: false,
+          },
+          allowList: {
+            e164: true,
+            E164: true,
+            isValidE164: true,
+          },
+        },
+      ],
       "unicorn/no-null": "off",
       "unicorn/no-array-reduce": "off",
       "unicorn/no-process-exit": "off",

--- a/src/client.ts
+++ b/src/client.ts
@@ -32,9 +32,9 @@ function capErrorMessage(message: string, max: number = MERCURY_ERROR_MESSAGE_MA
   if (message.length <= max) return message;
   // Reserve the marker length out of the budget so the final string is
   // always ≤ max + marker (predictable upper bound for callers).
-  const headLen = Math.ceil((max - TRUNCATION_MARKER.length) / 2);
-  const tailLen = Math.floor((max - TRUNCATION_MARKER.length) / 2);
-  return message.slice(0, headLen) + TRUNCATION_MARKER + message.slice(-tailLen);
+  const headLength = Math.ceil((max - TRUNCATION_MARKER.length) / 2);
+  const tailLength = Math.floor((max - TRUNCATION_MARKER.length) / 2);
+  return message.slice(0, headLength) + TRUNCATION_MARKER + message.slice(-tailLength);
 }
 
 export class MercuryError extends Error {
@@ -80,7 +80,7 @@ export class MercuryClient {
     // schema level).
     const encodedPath = path
       .split("/")
-      .map((seg, i) => (i === 0 || seg.length === 0 ? seg : encodeURIComponent(seg)))
+      .map((seg, index) => (index === 0 || seg.length === 0 ? seg : encodeURIComponent(seg)))
       .join("/");
     const url = new URL(this.baseUrl + encodedPath);
     if (init.query) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -122,8 +122,8 @@ const callHistory = new Map<string, number[]>();
 let stateLoaded = false;
 
 function getStateFile(): string {
-  const dir = process.env.MERCURY_MCP_STATE_DIR || join(homedir(), ".mercury-mcp");
-  return join(dir, "ratelimit.json");
+  const directory = process.env.MERCURY_MCP_STATE_DIR || join(homedir(), ".mercury-mcp");
+  return join(directory, "ratelimit.json");
 }
 
 function loadCallHistory(): void {
@@ -236,7 +236,7 @@ function sleepSync(ms: number): void {
 }
 /* v8 ignore stop */
 
-function withRateLimitLock<T>(fn: () => T): T {
+function withRateLimitLock<T>(function_: () => T): T {
   const lockPath = getLockFile();
   // Best-effort: ensure the parent dir exists. mkdirSync is idempotent,
   // and persistCallHistory does this too — but if we fail to acquire
@@ -262,7 +262,7 @@ function withRateLimitLock<T>(fn: () => T): T {
         console.error(
           `[ratelimit] cannot create lockfile ${lockPath}: ${(error as Error).message}; proceeding without inter-process lock`,
         );
-        return fn();
+        return function_();
       }
       // Stale-lock detection: reclaim a lockfile whose mtime is older
       // than LOCK_STALE_MS (process crashed between open and unlink).
@@ -290,14 +290,14 @@ function withRateLimitLock<T>(fn: () => T): T {
         console.error(
           `[ratelimit] lock contention on ${lockPath} after ${LOCK_TIMEOUT_MS}ms; proceeding without inter-process lock`,
         );
-        return fn();
+        return function_();
       }
       sleepSync(LOCK_RETRY_MS);
       continue;
       /* v8 ignore stop */
     }
     try {
-      return fn();
+      return function_();
     } finally {
       // Order matters: close before rm so we don't unlink a file we
       // still hold an fd on (POSIX is fine with it, but Windows isn't).

--- a/src/prompts/invoicing.ts
+++ b/src/prompts/invoicing.ts
@@ -153,11 +153,11 @@ export function registerInvoicingPrompts(server: McpServer): void {
       argsSchema: CreateCustomerArgs,
     },
     ({ name, email, address }) => {
-      const n = promptSafe(name);
-      const e = promptSafe(email);
-      const a = address ? promptSafe(address) : undefined;
+      const nameSafe = promptSafe(name);
+      const emailSafe = promptSafe(email);
+      const addressSafe = address ? promptSafe(address) : undefined;
       return {
-        description: `Create AR customer "${n}"`,
+        description: `Create AR customer "${nameSafe}"`,
         messages: [
           {
             role: "user" as const,
@@ -173,11 +173,11 @@ export function registerInvoicingPrompts(server: McpServer): void {
                 `invoice selection ambiguous in the Mercury Dashboard and is NOT what the ` +
                 `user wants.\n` +
                 `2. Call \`mercury_create_customer\` with:\n` +
-                `   - name: "${n}"\n` +
-                `   - email: "${e}"\n` +
-                (a
+                `   - name: "${nameSafe}"\n` +
+                `   - email: "${emailSafe}"\n` +
+                (addressSafe
                   ? `   - address: <parse the string below into { street, city, state, postalCode, country }>\n` +
-                    `     Source address: "${a}"\n` +
+                    `     Source address: "${addressSafe}"\n` +
                     `     If the parsing is ambiguous, STOP and ask the user to confirm the ` +
                     `split rather than guessing.\n`
                   : `   (no address supplied — will default to the workspace's on-file address)\n`) +

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -168,7 +168,7 @@ export function registerInvoiceTools(server: McpServer, client: MercuryClient): 
       const current = await client.get<Record<string, unknown>>(`/ar/invoices/${invoiceId}`);
       // Strip read-only fields Mercury rejects in the update payload
       const {
-        id: _i,
+        id: _index,
         slug: _s,
         status: _st,
         amount: _a,


### PR DESCRIPTION
Pass 3 of the unicorn adoption — full plan in klodr/eslint-plugin-security-mcp#41. Cross-repo probe sized the 13-entry allowList (args, arg, opts, msg, err, res, val, tmp, env, pkg, obj, params, ext). E.164 phone constants exempted via specific allowList. Residuals fixed inline (rename to full word).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality standards and linting configurations.

* **Refactor**
  * Standardized code conventions throughout the codebase and improved data handling robustness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/188)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->