### PR TITLE
chore(ci): reduce release-please trigger to 1 workflow_run

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,8 +35,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: release-please-${{ github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   release-please:
@@ -48,7 +48,7 @@ jobs:
     # state. `workflow_dispatch` invocations always pass through.
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     permissions:
-      actions: read         # the gate step below reads workflow-runs of OTHER workflows on this SHA
+      actions: read # the gate step below reads workflow-runs of OTHER workflows on this SHA
       contents: write
       pull-requests: write
     steps:


### PR DESCRIPTION
Trigger sur CodeQL Advanced uniquement (le plus lent) + concurrency SHA-based cancel-in-progress. Gate cross-workflow inchangé.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow trigger narrowed to run only after the CodeQL Advanced workflow completes.
  * Concurrency handling updated to group by commit SHA and to cancel in-progress runs for the same group, reducing duplicate releases.
  * Minor reformatting of job permission lines (no permission scope changes).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/189)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->