### PR TITLE
ci: bump reusable SHAs to current klodr/.github main (orphan fix)

### DIFF
--- a/.github/workflows/auto-merge-release-please.yml
+++ b/.github/workflows/auto-merge-release-please.yml
@@ -39,7 +39,7 @@ jobs:
     # but matching here means the secrets are only forwarded for the one
     # event that needs them, and human/dependabot PRs short-circuit early.
     if: ${{ github.event.pull_request.user.login == 'klodr-release-please[bot]' }}
-    uses: klodr/.github/.github/workflows/reusable-auto-merge-release-please.yml@5a3a5093bc93bc2a682b5a0cb438149af2516f4c
+    uses: klodr/.github/.github/workflows/reusable-auto-merge-release-please.yml@63627d28c0e716176f24f06f4d3cad6c1abf3648
     secrets:
       RELEASE_PLEASE_CLIENT_ID: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
       RELEASE_PLEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ concurrency:
 
 jobs:
   ci:
-    uses: klodr/.github/.github/workflows/reusable-node-ci.yml@31517bee59b358945f7af0fdb3960085e0f3ec78
+    uses: klodr/.github/.github/workflows/reusable-node-ci.yml@63627d28c0e716176f24f06f4d3cad6c1abf3648
     permissions:
       contents: read
       id-token: write
     with:
-      codecov-slug: 'klodr/mercury-invoicing-mcp'
-      coverage-strategy: 'always'
+      codecov-slug: "klodr/mercury-invoicing-mcp"
+      coverage-strategy: "always"

--- a/.github/workflows/leak-detect.yml
+++ b/.github/workflows/leak-detect.yml
@@ -35,7 +35,7 @@ jobs:
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository
       && github.event.pull_request.user.login != 'dependabot[bot]'
-    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@e302f5295abbccbfbb36769721cdde1529013ba3
+    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@63627d28c0e716176f24f06f4d3cad6c1abf3648
     secrets:
       leak-detect-client-id: ${{ secrets.LEAK_DETECT_CLIENT_ID }}
       leak-detect-app-private-key: ${{ secrets.LEAK_DETECT_APP_PRIVATE_KEY }}

--- a/.github/workflows/lint-yaml-md.yml
+++ b/.github/workflows/lint-yaml-md.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   lint:
-    uses: klodr/.github/.github/workflows/reusable-lint-yaml-md.yml@26b7f93b5a39c544f4414ada76cd2c79d9732bbd
+    uses: klodr/.github/.github/workflows/reusable-lint-yaml-md.yml@63627d28c0e716176f24f06f4d3cad6c1abf3648
     with:
       markdownlint-globs: |
         **/*.md


### PR DESCRIPTION
The previously pinned SHAs (`26b7f93b`, `e302f529`, `5a3a5093`, `31517bee`) became orphans after their PRs were squash-merged on klodr/.github — they exist as commits but are no longer reachable from any branch. GitHub Actions now refuses to load reusable workflows from unreachable SHAs, causing startup_failure with `referenced_workflows: []` and 0 spawned jobs on every PR.

Bumps all 4 caller workflows (ci.yml, lint-yaml-md.yml, auto-merge-release-please.yml, leak-detect.yml) to current klodr/.github main HEAD `63627d28`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to use newer versions of reusable workflow dependencies for improved CI/CD pipeline reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->