### PR TITLE
ci(leak-detect): bump to inline-JWT reusable + drop client-id

### DIFF
--- a/.github/workflows/leak-detect.yml
+++ b/.github/workflows/leak-detect.yml
@@ -35,7 +35,6 @@ jobs:
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository
       && github.event.pull_request.user.login != 'dependabot[bot]'
-    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@63627d28c0e716176f24f06f4d3cad6c1abf3648
+    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@7987f59050ff9ee614d21b603e4ba87ace27f7d9
     secrets:
-      leak-detect-client-id: ${{ secrets.LEAK_DETECT_CLIENT_ID }}
       leak-detect-app-private-key: ${{ secrets.LEAK_DETECT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Bumps reusable workflow SHA to klodr/.github main `7987f590` (inline JWT signing fix) and drops the now-unused `leak-detect-client-id` secret from the call (App ID is hardcoded in the reusable since GH Actions masks secret values at runtime, defeating int() parsing — and App IDs are public anyway).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal security scanning workflow to the latest version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->