### PR TITLE
ci(leak-detect): bump reusable to skip bot-authored PRs

### DIFF
--- a/.github/workflows/leak-detect.yml
+++ b/.github/workflows/leak-detect.yml
@@ -35,6 +35,6 @@ jobs:
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository
       && github.event.pull_request.user.login != 'dependabot[bot]'
-    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@7987f59050ff9ee614d21b603e4ba87ace27f7d9
+    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@33ff8e518ecb7a799f114dc83ba06c9f0d660845
     secrets:
       leak-detect-app-private-key: ${{ secrets.LEAK_DETECT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Picks up klodr/.github#39 (`33ff8e51`) — leak-detect scan now skips when `endsWith(github.actor, '[bot]')`, so Dependabot bumps and `klodr-release-please[bot]` PRs merge without needing a manual ruleset bypass. Human PRs unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal GitHub Actions workflow configuration for improved leak detection scanning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klodr/mercury-invoicing-mcp/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->