### PR TITLE
ci: bump reusable-node-ci pin (real v7.0.0 commit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: klodr/.github/.github/workflows/reusable-node-ci.yml@91d67772fb922f21057938eed7431c48a78c70e5 # main @ 2026-07-04
+    uses: klodr/.github/.github/workflows/reusable-node-ci.yml@3cff28796830bc3ed5fd0ff801663ffe4407466c # main @ 2026-07-04 (v7.0.0 real commit)
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Suite de klodr/.github#47/#48 (trouvaille Codex) : la révision précédente épinglait codecov-action sur l'**objet tag** annoté v7.0.0 (`e53489f…`, pas un commit). On pointe la révision qui épingle le **commit réel** `fb8b358…`.