### PR TITLE
ci(release): npm OIDC trusted publishing on Node 24

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -25,7 +25,7 @@ maintainer commits to, and limits that callers must account for.
   npm publishes carry [provenance](https://docs.npmjs.com/generating-provenance-statements).
   All GitHub Actions in `.github/workflows/` are pinned by full commit SHA.
 - **Least-privilege CI**: the release workflow is split into a read-only build
-  job and a release-only publish job that holds `NPM_TOKEN`.
+  job and a release-only publish job that mints short-lived npm credentials via OIDC trusted publishing (no long-lived npm token exists).
 - **Defense against runaway agents**: rate-limiting middleware caps write
   operations per bucket (e.g. `payments`, `customers_write`, `invoices_write`)
   with a **dual-window policy**: each call must satisfy both a daily (24h)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: Release & npm publish
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
 
 # Default workflow permissions: read-only. The publish job below escalates
@@ -45,19 +45,22 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
-      contents: write       # upload signed artifacts to the GitHub Release
-      id-token: write       # npm provenance + Sigstore keyless signing
-      attestations: write   # actions/attest-build-provenance writes to the attestation API
+      contents: write # upload signed artifacts to the GitHub Release
+      id-token: write # npm provenance + Sigstore keyless signing
+      attestations: write # actions/attest-build-provenance writes to the attestation API
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup Node 22
+      - name: Setup Node 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          # Node 24 ships npm >= 11.5.1, which supports OIDC trusted
+          # publishing out of the box. No npm cache and no registry-url:
+          # setup-node's registry-url writes an npm auth line that (with
+          # no token) forces the classic-auth path instead of the OIDC
+          # exchange.
+          node-version: "24"
 
       - name: Install dependencies
         run: npm ci
@@ -245,5 +248,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public --provenance --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Do not keep the write-scoped job token in git config; the
+          # release steps use the GH_TOKEN env instead.
+          persist-credentials: false
 
       - name: Setup Node 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -59,8 +63,10 @@ jobs:
           # publishing out of the box. No npm cache and no registry-url:
           # setup-node's registry-url writes an npm auth line that (with
           # no token) forces the classic-auth path instead of the OIDC
-          # exchange.
+          # exchange. package-manager-cache pins that choice once the
+          # action reaches v7 (auto-cache by default).
           node-version: "24"
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci

--- a/docs/ASSURANCE_CASE.md
+++ b/docs/ASSURANCE_CASE.md
@@ -44,7 +44,7 @@ weaknesses have been countered.
    ships malicious code. Mitigations: Socket Security PR alerts,
    Dependabot, CodeQL, Snyk, OpenSSF Scorecard.
 4. **Compromised CI workflow** — an attacker pushes a workflow change
-   that exfiltrates `NPM_TOKEN`. Mitigations: every action pinned by
+   that abuses the publish job's OIDC identity (no long-lived npm token exists to exfiltrate). Mitigations: every action pinned by
    full commit SHA, build/publish jobs split with least-privilege
    tokens, branch protection requires PR + review + CodeQL on workflows
    themselves (`actions` language scanned by CodeQL Advanced).
@@ -95,7 +95,7 @@ boundary.
 
 | Principle | Implementation |
 |---|---|
-| **Least privilege** | `release.yml` is split into a read-only `build` job and a `publish` job that holds `NPM_TOKEN` and runs only on tag pushes. CodeQL job's permissions limited to `security-events: write`, `contents: read`. Default workflow permissions: `contents: read`. |
+| **Least privilege** | `release.yml` is split into a read-only `build` job and a `publish` job that mints short-lived npm credentials via OIDC trusted publishing and runs only on tag pushes. CodeQL job's permissions limited to `security-events: write`, `contents: read`. Default workflow permissions: `contents: read`. |
 | **Defense in depth** | Zod schema validation **and** UUID format check **and** URL-encoding per segment for path-injected IDs. Sigstore signature **and** SLSA attestation **and** npm provenance for releases. |
 | **Fail closed** | 30 s fetch timeout. Missing `MERCURY_API_KEY` → exit at startup. Invalid rate-limit env value → log + fall back to default (no silent disable). |
 | **Minimise attack surface** | No sourcemaps in published tarball (`prepublishOnly` sets `NODE_ENV=production`). Only `dist/`, `README.md`, `LICENSE` in the npm files allowlist. No HTTP transport (stdio only); no listening sockets. |

--- a/docs/CONTINUITY.md
+++ b/docs/CONTINUITY.md
@@ -16,7 +16,7 @@ interruption (≤1 week) if I become unavailable.
 - **Build & release pipeline** is fully automated in
   [`.github/workflows/release.yml`](../.github/workflows/release.yml) and
   documented in [`CHANGELOG.md`](../CHANGELOG.md). A fork can reproduce
-  releases by configuring `NPM_TOKEN` and pushing a tag.
+  releases by registering their fork as an npm trusted publisher (repo + `release.yml`) and pushing a tag.
 - **No proprietary infrastructure**: no private dashboards, no
   unmanageable accounts. All third-party integrations (CodeQL, Scorecard,
   CodeRabbit, Socket Security, Codecov, Snyk, Dependabot) are free and
@@ -30,7 +30,7 @@ If the maintainer is confirmed unable to continue, anyone can:
 2. Continue issue triage, PR review, and merges in the fork.
 3. Publish releases under their own npm scope (e.g.
    `@yourname/mercury-invoicing-mcp`) following the documented release
-   flow — this typically takes minutes once `NPM_TOKEN` is set.
+   flow — this typically takes minutes once the trusted publisher is registered on npmjs.com.
 4. Update downstream MCP client configs to point at the fork's package.
 
 ### Takeover checklist for the first release

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -4,17 +4,17 @@
 
 ### One-time setup (manual)
 
+Publishing uses **npm OIDC trusted publishing** — no token, no secret.
+
 1. Create an [npmjs.com](https://www.npmjs.com/) account if you don't have one.
-2. Go to [https://www.npmjs.com/settings/your-username/tokens](https://www.npmjs.com/settings/your-username/tokens) → **Generate New Token** → **Granular Access Token**:
-   - Token name: `mercury-invoicing-mcp publish`
-   - Expiration: 1 year (or Custom)
-   - Permissions: **Read and write**
-   - Packages: `mercury-invoicing-mcp` (after first publish, before that select "Allow this token to publish new packages on npm")
-3. Copy the token (starts with `npm_`).
-4. Add it to the repo as a GitHub secret:
-   - Go to https://github.com/klodr/mercury-invoicing-mcp/settings/secrets/actions/new
-   - Name: `NPM_TOKEN`
-   - Secret: paste the token
+2. On the package page → **Settings** → **Trusted Publisher** → GitHub Actions:
+   - Organization or user: `klodr`
+   - Repository: `mercury-invoicing-mcp`
+   - Workflow filename: `release.yml`
+   - Environment: leave empty; Allowed actions: **Publish**
+3. That's it: `release.yml` mints short-lived credentials from the
+   workflow's OIDC identity at publish time (npm >= 11.5.1, bundled
+   with Node 24 in the publish job).
 
 ### First publish (manual, locally)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -997,12 +997,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -2895,20 +2895,20 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -2918,17 +2918,30 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4424,9 +4437,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -6192,9 +6205,9 @@
       }
     },
     "node_modules/markdownlint-cli2/node_modules/js-yaml": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.0.tgz",
-      "integrity": "sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "dev": true,
       "funding": [
         {
@@ -6923,9 +6936,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -7434,9 +7447,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -7454,7 +7467,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -93,9 +93,11 @@
     ]
   },
   "overrides": {
-    "fast-uri": "3.1.2",
+    "fast-uri": "3.1.4",
     "esbuild": "0.28.1",
-    "js-yaml@^4.0.0": "4.3.0"
+    "js-yaml@^4.0.0": "4.3.0",
+    "js-yaml@^5.0.0": "5.2.2",
+    "@hono/node-server": "2.0.12"
   },
   "lint-staged": {
     "*.{ts,tsx,js,mjs,cjs,mts}": [


### PR DESCRIPTION
Bascule identique à gmail-mcp (déjà publié en 1.3.1 via OIDC) et faxdrop :
- `NPM_TOKEN` (expiré → publish cassés depuis mai, npm bloqué à 0.17.2) remplacé par le **trusted publishing OIDC** (repo + `release.yml` enregistrés sur npmjs.com).
- Job publish en **Node 24** (npm 11.16 embarqué, ≥ 11.5.1 requis), sans cache npm ni `registry-url` (évite le `_authToken` vide qui force l'auth classique).

`Release-As: 0.18.1` pour repartir sur un tag qui inclut l'OIDC (le tag v0.18.0 pointe le workflow pré-OIDC). npm passera 0.17.2 → 0.18.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores / Maintenance**
  - Updated the release workflow to trigger reliably on version tag patterns.
  - Migrated package publishing to npm OIDC trusted publishing, removing reliance on long-lived npm tokens.
  - Adjusted the publish job configuration to use the trusted publishing path.

- **Documentation**
  - Updated publishing guides to instruct npm trusted publisher setup via GitHub Actions.
  - Refreshed assurance and continuity documentation to reflect the tokenless trusted-publishing process.
  - Updated security policy text describing credential handling.

- **Dependencies**
  - Bumped/adjusted dependency overrides for fast-uri, js-yaml, and `@hono/node-server`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->